### PR TITLE
fix compatibility with coffeescript 1.6 source map files

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -7,7 +7,7 @@ function mapSourcePosition(cache, position) {
   if (!sourceMap && fs.existsSync(position.source)) {
     // Get the URL of the source map
     var fileData = fs.readFileSync(position.source, 'utf8');
-    var match = /\/\/@\s*sourceMappingURL=(.*)\s*$/.exec(fileData);
+    var match = /\/\/@\s*sourceMappingURL=(.*)\s*$/m.exec(fileData);
     if (!match) return position;
     var sourceMappingURL = match[1];
 


### PR DESCRIPTION
CoffeeScript 1.6 introduced builtin support for source map files. Unfortunately, they place the sourceMappiungURL comment at the top of the generated JS file, not the bottom. This means that the regexp in source-map-support.js on line 10 fails because it's not doing a multiline match.

For now, it assumes that the first comment it finds indicating a sourceMappingURL is the right one to use. I'm not certain what it should do if it finds multiple matches which disagree on the URL.

Thanks for considering this pull request.
