### PR TITLE
add support to not listen for uncaught exceptions

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -99,8 +99,7 @@ Error.prepareStackTrace = function(error, stack) {
   }).join('');
 };
 
-// Mimic node's stack trace printing when an exception escapes the process
-process.on('uncaughtException', function(error) {
+var actOnUncaughtException = function(error) {
   if (!error || !error.stack) {
     console.log('Uncaught exception:', error);
     process.exit();
@@ -125,4 +124,21 @@ process.on('uncaughtException', function(error) {
   }
   console.log(error.stack);
   process.exit();
-});
+};
+
+// Mimic node's stack trace printing when an exception escapes the process
+process.on('uncaughtException', actOnUncaughtException)
+
+// Sometimes we want to convert the stack traces displayed using
+// source-map-support, but other code handles logging the error and
+// handling the uncaught exception.  Examples include test frameworks
+// and servers which should stay running as much as possible.  The
+// 'convertOnly' function below turns off listening for uncaught
+// exceptions.
+var convertOnly = function() {
+    process.removeListener("uncaughtException", actOnUncaughtException)
+};
+
+module.exports = {
+    convertOnly: convertOnly
+}


### PR DESCRIPTION
While exiting on an uncaught exception is a reasonable default, there are situations where it's less than ideal (like running inside a test framework); however, it is nice to still have a CS based stack trace instead of a js based one. This change provides an option to disable the automatic termination of the process while retaining the CS based stack trace.

I think the change is a bit of a hack, but I couldn't think of any other way to do it without breaking backward compatibility. I'm open to suggestions on that front as well as a better name for the function added. If you're open to breaking backwards compatibility, then I'd suggest making the module export a function which takes an argument of either true or false which indicates whether to end the process on an uncaught exception. Then (in coffeescript) the require would look like:
sms = require("source-map-support")(true)

Thanks.
