### PR TITLE
Export mapSourcePosition so that it's possible to use externally.

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -2,7 +2,7 @@ var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var path = require('path');
 var fs = require('fs');
 
-function mapSourcePosition(cache, position) {
+exports.mapSourcePosition = mapSourcePosition = function(cache, position) {
   var sourceMap = cache[position.source];
   if (!sourceMap && fs.existsSync(position.source)) {
     // Get the URL of the source map


### PR DESCRIPTION
I've found mapSourcePosition very useful in my own custom exception handlers, it'd be great if this could be exposed.
