### PR TITLE
Support data-uri format

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -11,13 +11,24 @@ exports.mapSourcePosition = mapSourcePosition = function(cache, position) {
     if (!match) return position;
     var sourceMappingURL = match[1];
 
-    // Support source map URLs relative to the source URL
-    var dir = path.dirname(position.source);
-    sourceMappingURL = path.resolve(dir, sourceMappingURL);
+    var sourceMapData;
 
-    // Parse the source map
-    if (fs.existsSync(sourceMappingURL)) {
-      var sourceMapData = fs.readFileSync(sourceMappingURL, 'utf8');
+    var dataUrlPrefix = "data:application/json,base64,";
+    if (sourceMappingURL.slice(0, dataUrlPrefix.length).toLowerCase() == dataUrlPrefix) {
+      // Support source map URL as a data url
+      sourceMapData = new Buffer(sourceMappingURL.slice(dataUrlPrefix.length), "base64").toString();
+    }
+    else {
+      // Support source map URLs relative to the source URL
+      var dir = path.dirname(position.source);
+      sourceMappingURL = path.resolve(dir, sourceMappingURL);
+
+      if (fs.existsSync(sourceMappingURL)) {
+        sourceMapData = fs.readFileSync(sourceMappingURL, 'utf8');
+      }
+    }
+
+    if (sourceMapDat) {
       sourceMap = {
         url: sourceMappingURL,
         map: new SourceMapConsumer(sourceMapData)


### PR DESCRIPTION
[source-map spec](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit) says:

```
Note: <url> maybe a data URI.  Using a data URI along with “sourcesContent”
allow for a completely self-contained source-map.
```

And this pull-req implements data-uri format. Can you review it please?
