### PR TITLE
Documentation on basic custom usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,39 @@ To use a valid source map (generated using something like [source-map-index-gene
 
 ### Demos 
 
+#### Basic Demo
+
+original.js:
+
+    throw new Error("test");
+
+compiled.js:
+
+    //#sourceMappingURL=original.sourcemap.json
+    require('source-map-support').install();
+
+    throw new Error("test");
+
+original.sourcemap.json:
+
+    {"version":3,"file":"compiled.js","sources":["original.js"],"names":[],"mappings":";;;AAAA,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC"}
+
+After running compiled.js you should get the following outout:
+
+    /path/to/original.js:1
+    throw new Error("test");
+          ^
+    Error: test
+        at Object.<anonymous> (/path/to/original.js:1:7)
+        at Module._compile (module.js:456:26)
+        at Object.Module._extensions..js (module.js:474:10)
+        at Module.load (module.js:356:32)
+        at Function.Module._load (module.js:312:12)
+        at Function.Module.runMain (module.js:497:10)
+        at startup (node.js:119:16)
+        at node.js:901:3
+
+
 #### CoffeeScript Demo
 
 The following terminal commands show a stack trace in node with CoffeeScript filenames:


### PR DESCRIPTION
Adding documentation that makes it easier to understand how to use source maps in a custom project (ie one that isn't CoffeeScript or TypeScript).
