### PR TITLE
Update to source-map 0.1.26.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "node_modules/mocha/bin/mocha"
   },
   "dependencies": {
-    "source-map": "0.1.24"
+    "source-map": "0.1.26"
   },
   "devDependencies": {
     "mocha": "1.8.1"


### PR DESCRIPTION
0.1.26 fixes a bug in processing maps with no mappings. (It's not in a class used directly by source-map-support yet, but upgrading shouldn't hurt.)
