### PR TITLE
added retrieveFile option

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -230,6 +230,11 @@ exports.install = function(options) {
     emptyCacheBetweenOperations = 'emptyCacheBetweenOperations' in options ?
       options.emptyCacheBetweenOperations : false;
 
+    // Allow sources to be found by methods other than reading the files
+    // directly from disk.
+    if (options.retrieveFile)
+      retrieveFile = options.retrieveFile;
+
     // Allow source maps to be found by methods other than reading the files
     // directly from disk.
     if (options.retrieveSourceMap)


### PR DESCRIPTION
I added an option for the `install` function so I can override the default source file loading behavior.

One use-case are on-the-fly compilers such as the require-cs plugin for requirejs. The original file on disk does not have the sourceMappingURL comment since its directly pointing to the CoffeeScript file. This comment is instead injected in the compiled text before sending it to eval().

With this new option, I can modify my fork of require-cs to directly provide source and source map data and my stack traces now display the proper original line/column numbers.
