### PR TITLE
should not return a url when we have a dataUrl

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -69,6 +69,7 @@ var retrieveSourceMap = function (source) {
   if (sourceMappingURL.slice(0, dataUrlPrefix.length).toLowerCase() == dataUrlPrefix) {
     // Support source map URL as a data url
     sourceMapData = new Buffer(sourceMappingURL.slice(dataUrlPrefix.length), "base64").toString();
+    sourceMappingURL = null;
   } else {
     // Support source map URLs relative to the source URL
     var dir = path.dirname(source);


### PR DESCRIPTION
If you return a dataUrl in the url field, the mapSourcePosition function will try to treat it as an actual url.  In PhantomJS, this causes the path.dirname() function to basically fall into a blackhole trying to process a path regex on such a large string.
