### PR TITLE
exporting wrapCallSite directly for other components to be used

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -218,6 +218,8 @@ function handleUncaughtExceptions(error) {
   process.exit();
 }
 
+exports.wrapCallSite = wrapCallSite;
+
 exports.install = function(options) {
   if (!alreadyInstalled) {
     alreadyInstalled = true;


### PR DESCRIPTION
I'm working on bringing bunyan together with node-source-map. Because both components are using `Error.prepareStackTrace` the regular install method is of no use with that. Plz export wrapCallSite directly, so it is usable for other components.

Thanks!
