### PR TITLE
Making use of console.error

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -331,11 +331,11 @@ function getErrorSource(error) {
 // Mimic node's stack trace printing when an exception escapes the process
 function handleUncaughtExceptions(error) {
   if (!error || !error.stack) {
-    console.log('Uncaught exception:', error);
+    console.error('Uncaught exception:', error);
   } else {
     var source = getErrorSource(error);
-    if (source !== null) console.log(source);
-    console.log(error.stack);
+    if (source !== null) console.error(source);
+    console.error(error.stack);
   }
   process.exit(1);
 }


### PR DESCRIPTION
NodeJS outputs errors to stderr. Making use of console.error(...) instead of console.log(...) makes node-source-map-support compatible with IDEs like Webstorm to get stack traces.