### PR TITLE
Check XMLHttpRequest is a function for isInBrowser

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -15,7 +15,7 @@ var fileContentsCache = {};
 var sourceMapCache = {};
 
 function isInBrowser() {
-  return typeof window !== 'undefined';
+  return ((typeof window !== 'undefined') && (typeof XMLHttpRequest === 'function'));
 }
 
 function retrieveFile(path) {


### PR DESCRIPTION
This change allows me to do testing in node of client code using jsdom with proper sourcemap support.

I don't have XMLHttpRequest defined during that time and therefore am not running in the browser.

Thanks.