### PR TITLE
Don't print an error and exit on uncaughtException if there are other uncaughtException listeners present.

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -335,7 +335,9 @@ function getErrorSource(error) {
 
 // Mimic node's stack trace printing when an exception escapes the process
 function handleUncaughtExceptions(error) {
-  if (!error || !error.stack) {
+  if (process.listeners('uncaughtException').length > 1) {
+    return;
+  } else if (!error || !error.stack) {
     console.log('Uncaught exception:', error);
   } else {
     var source = getErrorSource(error);

--- a/test.js
+++ b/test.js
@@ -296,6 +296,17 @@ it('handleUncaughtExceptions is false', function(done) {
   ]);
 });
 
+it('handleUncaughtExceptions is true with existing listener', function(done) {
+  compareStdout(done, createSingleLineSourceMap(), [
+    'process.on("uncaughtException", function() { console.log("exception handler"); });',
+    'function foo() { throw new Error("this is the error"); }',
+    'require("./source-map-support").install({ handleUncaughtExceptions: false });',
+    'process.nextTick(foo);'
+  ], [
+    'exception handler'
+  ]);
+});
+
 it('default options with empty source map', function(done) {
   compareStdout(done, createEmptySourceMap(), [
     '',


### PR DESCRIPTION
Node's default behavior is to only print an exception and exit if there is no other uncaughtException handler registered.  This emulates that default behavior by bypassing the uncaughtException handler if other handlers are registered.