### PR TITLE
Remove hard-coded path to test executable.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.2.10",
   "main": "./source-map-support.js",
   "scripts": {
-    "test": "node_modules/mocha/bin/mocha"
+    "test": "mocha"
   },
   "dependencies": {
     "source-map": "0.1.32"


### PR DESCRIPTION
Such paths are brittle, due to npm deduping, `mocha` is not guaranteed to be at this location, it may be higher in the tree.

node_modules/.bin is added to the PATH env var for npm scripts so "mocha" on its own is both shorter and will more robustly be able to locate the mocha executable.

Note that is is a problem in the build script as well, for which you could use something like [npm-run](https://www.npmjs.com/package/npm-run)