### PR TITLE
Check for 200 response code.

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -29,7 +29,10 @@ function retrieveFile(path) {
       var xhr = new XMLHttpRequest();
       xhr.open('GET', path, false);
       xhr.send(null);
-      var contents = xhr.readyState === 4 ? xhr.responseText : null;
+      var contents = null
+      if (xhr.readyState === 4 && xhr.status === 200) {
+        contents = xhr.responseText
+      }
     }
 
     // Otherwise, use the filesystem


### PR DESCRIPTION
Without this check, missing sourcemaps cause the package to continue as if the 404 message is the sourcemap, leading to crashes when responses like "Not Found" cannot be parsed as source maps.