### PR TITLE
Add `build` npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.2.10",
   "main": "./source-map-support.js",
   "scripts": {
+    "build": "node build.js",
     "test": "mocha"
   },
   "dependencies": {


### PR DESCRIPTION
Abstract the build process behind `npm run build`.

It is a good practice as it makes the transition to another build system easier.