### PR TITLE
Use license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,5 @@
   "bugs": {
     "url": "https://github.com/evanw/node-source-map-support/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ]
+  "license": "MIT",
 }


### PR DESCRIPTION
Array deprecated in `npm@2.10.0`

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license