### PR TITLE
Fix inline source-map support with charset in the data url

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -92,10 +92,9 @@ function retrieveSourceMap(source) {
 
   // Read the contents of the source map
   var sourceMapData;
-  var dataUrlPrefix = "data:application/json;base64,";
-  if (sourceMappingURL.slice(0, dataUrlPrefix.length).toLowerCase() == dataUrlPrefix) {
+  if(/^data:application\/json[^,]+base64,/.test(sourceMappingURL)) {
     // Support source map URL as a data url
-    sourceMapData = new Buffer(sourceMappingURL.slice(dataUrlPrefix.length), "base64").toString();
+    sourceMapData = new Buffer(sourceMappingURL.slice(sourceMappingURL.indexOf(',')+1), "base64").toString();
     sourceMappingURL = null;
   } else {
     // Support source map URLs relative to the source URL


### PR DESCRIPTION
Inline source map prefix should contain an charset:
`data:application/json;charset:utf-8;base64,`

This is the case with the last releases of browserify for instance.
This fix make inline source map detection more flexible to support 
this *kind* of data url (not only with charset) and use a regexp instead
of a static string: `/^data:application\/json[^,]+base64,/`

(I didn’t push the generated `browser-source-map-support.js` with this
PR, do you want me to ?)