### PR TITLE
Adding path cleaning

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -19,6 +19,8 @@ function isInBrowser() {
 }
 
 function retrieveFile(path) {
+  // Trim the path to make sure there is no extra whitespace.
+  path = path.trim();
   if (path in fileContentsCache) {
     return fileContentsCache[path];
   }


### PR DESCRIPTION
For some reason, some files will have a trailing new line for their
name. This code cleans up the path to no longer have the trailing space.