### PR TITLE
added mapfile support

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -82,8 +82,15 @@ function retrieveSourceMapURL(source) {
   // picking up sourceMappingURLs from comments, strings, etc.
   var lastMatch, match;
   while (match = re.exec(fileData)) lastMatch = match;
-  if (!lastMatch) return null;
-  return lastMatch[1];
+  if (lastMatch) {
+    return lastMatch[1];
+  } else {
+    // Try the .map file
+    mapFile = source + '.map';
+    if (fs.existsSync(mapFile)) {
+      return mapFile;
+    }
+  }
 };
 
 // Can be overridden by the retrieveSourceMap option to install. Takes a


### PR DESCRIPTION
Since most compilers don't add mapfile directives in the generated source, and instead just generate a `.map` file with the same basename as the original file, I added support for that.

It uses the deprecated `fs.existSync()` method, and doesn't work on browsers. This was just a quick fix and may be a good starter point or patch for someone who needs this functionality.