### PR TITLE
support charset in data url

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -14,6 +14,9 @@ var fileContentsCache = {};
 // Maps a file path to a source map for that file
 var sourceMapCache = {};
 
+// Regex for detecting source maps
+var reSourceMap = /^data:application\/json[^,]+base64,/;
+
 function isInBrowser() {
   return ((typeof window !== 'undefined') && (typeof XMLHttpRequest === 'function'));
 }
@@ -97,10 +100,10 @@ function retrieveSourceMap(source) {
 
   // Read the contents of the source map
   var sourceMapData;
-  var dataUrlPrefix = "data:application/json;base64,";
-  if (sourceMappingURL.slice(0, dataUrlPrefix.length).toLowerCase() == dataUrlPrefix) {
+  if (reSourceMap.test(sourceMappingURL)) {
     // Support source map URL as a data url
-    sourceMapData = new Buffer(sourceMappingURL.slice(dataUrlPrefix.length), "base64").toString();
+    var rawData = sourceMappingURL.slice(sourceMappingURL.indexOf(',') + 1);
+    sourceMapData = new Buffer(rawData, "base64").toString();
     sourceMappingURL = null;
   } else {
     // Support source map URLs relative to the source URL


### PR DESCRIPTION
This is the fix first suggested by @nopnop in #65 but slightly modified for code readability and with added test.

> Inline source map prefix should contain an charset:
data:application/json;charset:utf-8;base64,

> This is the case with the last releases of browserify for instance.
This fix make inline source map detection more flexible to support 
this kind of data url (not only with charset) and use a regexp instead
of a static string: /^data:application\/json[^,]+base64,/

> (I didn’t push the generated browser-source-map-support.js with this
PR, do you want me to ?)