### PR TITLE
mimic node more closely

### DIFF
--- a/test.js
+++ b/test.js
@@ -415,3 +415,25 @@ it('finds source maps with charset specified', function() {
   }
   fs.unlinkSync('.generated.js');
 });
+
+it('handleUncaughtExceptions is true with existing listener', function(done) {
+  var source = [
+    'process.on("uncaughtException", function() { /* Silent */ });',
+    'function foo() { throw new Error("this is the error"); }',
+    'require("./source-map-support").install();',
+    'process.nextTick(foo);',
+    '//@ sourceMappingURL=.generated.js.map'
+  ];
+
+  fs.writeFileSync('.original.js', 'this is the original code');
+  fs.writeFileSync('.generated.js.map', createSingleLineSourceMap());
+  fs.writeFileSync('.generated.js', source.join('\n'));
+
+  child_process.exec('node ./.generated', function(error, stdout, stderr) {
+    fs.unlinkSync('.generated.js');
+    fs.unlinkSync('.generated.js.map');
+    fs.unlinkSync('.original.js');
+    assert.equal((stdout + stderr).trim(), '');
+    done();
+  });
+});


### PR DESCRIPTION
This is the fix first suggested by @crispy1989 in #46 but tweaked to work better and have correct tests.

> Node's default behavior is to only print an exception and exit if there is no other uncaughtException handler registered. This emulates that default behavior by bypassing the uncaughtException handler if other handlers are registered.

It also includes #76 so **pull that before** pulling this and this pull request should automatically be updated to only show the one relevant commit.

@evanw @julien-f If you want another maintainer I would be willing to help :)