### PR TITLE
Fix RangeError on large files

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -84,13 +84,19 @@ function retrieveSourceMapURL(source) {
 
   // Get the URL of the source map
   fileData = retrieveFile(source);
-  var re = /\/\/[#@]\s*sourceMappingURL=([^'"]+)\s*$/mg;
+  var re = /\/\/[#@]\s*sourceMappingURL=/mg;
   // Keep executing the search to find the *last* sourceMappingURL to avoid
   // picking up sourceMappingURLs from comments, strings, etc.
   var lastMatch, match;
   while (match = re.exec(fileData)) lastMatch = match;
   if (!lastMatch) return null;
-  return lastMatch[1];
+
+  var begin = lastMatch.index + lastMatch[0].length;
+  var end = fileData.indexOf("\n", begin);
+  if (end < 0) end = fileData.length;
+  while (end > begin && fileData[end - 1].match(/\s/)) end--;
+
+  return fileData.substring(begin, end);
 };
 
 // Can be overridden by the retrieveSourceMap option to install. Takes a


### PR DESCRIPTION
When the source file and/or the source map URL is sufficiently large (think several MB) the regexp search to find the URL can run into this issue: https://code.google.com/p/v8/issues/detail?id=3878

Change the regexp to look just for the prefix and extract the URL using substring, which scales better.

This now doesn't pay attention to single and double quotes anymore, reading the spec there seems to be no need for it. Do you know of quoted source map URLs in the wild?

FWIW we've run into the RangeError with a large webpack development bundle on Chrome Version 43.0.2357.130 (64-bit).