### PR TITLE
Change RegExp to be less greedy (Fixes #87).

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -84,7 +84,8 @@ function retrieveSourceMapURL(source) {
 
   // Get the URL of the source map
   fileData = retrieveFile(source);
-  var re = /\/\/[#@]\s*sourceMappingURL=([^'"]+)\s*$/mg;
+  //        //# sourceMappingURL=foo.js.map                       /*# sourceMappingURL=foo.js.map */
+  var re = /(?:\/\/[@#][ \t]+sourceMappingURL=([^\s'"]+?)[ \t]*$)|(?:\/\*[@#][ \t]+sourceMappingURL=([^\*]+?)[ \t]*(?:\*\/)[ \t]*$)/mg;
   // Keep executing the search to find the *last* sourceMappingURL to avoid
   // picking up sourceMappingURLs from comments, strings, etc.
   var lastMatch, match;


### PR DESCRIPTION
Change RegExp to be less greedy (Fixes #87). Add test and allow tests to run (and pass) on Windows.