### PR TITLE
Improve regular expression to catch non-parenthesized stack frames

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -334,11 +334,11 @@ function prepareStackTrace(error, stack) {
 
 // Generate position and snippet of original source with pointer
 function getErrorSource(error) {
-  var match = /\n    at [^(]+ \((.*):(\d+):(\d+)\)/.exec(error.stack);
+  var match = /^\s+at .*?(?:\(([^\s:]+):(\d+):(\d+)\)|([^\s:]+):(\d+):(\d+))$/m.exec(error.stack);
   if (match) {
-    var source = match[1];
-    var line = +match[2];
-    var column = +match[3];
+    var source = match[1] || match[4];
+    var line = +match[2] || +match[5];
+    var column = +match[3] || +match[6];
 
     // Support the inline sourceContents inside the source map
     var contents = fileContentsCache[source];


### PR DESCRIPTION
I was noticing the pointer was pointing to the wrong place on some stack dumps. The previous regular expression only captured frames of the form:

`at someFn (/path:line:col)`

... but this would skip certain frames of the form:

`at /path:line:col`

This regular expression catches both forms, as well as frames of the form:

`at Thing.(anonymous function) [as .js] (/path:line:col)`