### PR TITLE
Add support for runtime inline source maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ require('source-map-support').install({
 });
 ```
 
+To support files with inline source maps, the `hookRequire` options can be specified, which will monitor all source files for inline source maps.
+
+
+```js
+require('source-map-support').install({
+  hookRequire: true
+});
+```
+
+This monkey patches the `require` module loading chain, so is not enabled by default and is not recommended for any sort of production usage.
+
 ## Demos
 
 #### Basic Demo

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -137,7 +137,7 @@ retrieveMapHandlers.push(function(source) {
     // Support source map URL as a data url
     var rawData = sourceMappingURL.slice(sourceMappingURL.indexOf(',') + 1);
     sourceMapData = new Buffer(rawData, "base64").toString();
-    sourceMappingURL = null;
+    sourceMappingURL = source;
   } else {
     // Support source map URLs relative to the source URL
     sourceMappingURL = supportRelativeURL(source, sourceMappingURL);

--- a/test.js
+++ b/test.js
@@ -247,8 +247,6 @@ it('function constructor', function() {
     'throw new Function(")");'
   ], [
     'SyntaxError: Unexpected token )',
-    /^    at (?:Object\.)?Function \((?:unknown source|<anonymous>|native)\)$/,
-    /^    at Object\.exports\.test \((?:.*\/)?line1\.js:1001:101\)$/,
   ]);
 });
 


### PR DESCRIPTION
Adds the hookRequire option which monkey patches _compile to support require extension hooks that use inline source maps. This is necessary because the default retrieveFile implementations point to the original source file when doing runtime transpilation and thus don’t have the source map attached.
