### PR TITLE
Set sourceMappingURL to source if a data URL was used

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -136,7 +136,7 @@ retrieveMapHandlers.push(function(source) {
     // Support source map URL as a data url
     var rawData = sourceMappingURL.slice(sourceMappingURL.indexOf(',') + 1);
     sourceMapData = new Buffer(rawData, "base64").toString();
-    sourceMappingURL = null;
+    sourceMappingURL = source;
   } else {
     // Support source map URLs relative to the source URL
     sourceMappingURL = supportRelativeURL(source, sourceMappingURL);


### PR DESCRIPTION
If the source file contains a data URL as the sourceMappingURL, set the sourceMappingURL to the source itself. This then allows relative sources from the source map to be resolved.

As an example I have a file that [contains an inline source map](https://github.com/novemberborn/source-map-fixtures/blob/ef64e8c81fb2917666b50560d65ce4b778f3f304/fixtures/throws-inline.js). The source map has a `sourceRoot` pointing at `../src` ([see the same map in a file](https://github.com/novemberborn/source-map-fixtures/blob/ef64e8c81fb2917666b50560d65ce4b778f3f304/fixtures/throws-map-file.js.map)).

Without this PR the stack trace is rewritten to include a relative `../src/throws.js` path. With the PR it's rewritten to contain an absolute path.

I don't believe this regresses #26. I'm not sure how to add a test for this new behavior though.
