### PR TITLE
return native code CallSite as is

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -306,6 +306,10 @@ function cloneCallSite(frame) {
 }
 
 function wrapCallSite(frame) {
+  if(frame.isNative()) {
+    return frame;
+  }
+
   // Most call sites will return the source file from getFileName(), but code
   // passed to eval() ending in "//# sourceURL=..." will return the source file
   // from getScriptNameOrSourceURL() instead

--- a/test.js
+++ b/test.js
@@ -222,6 +222,16 @@ it('eval with sourceURL inside eval', function() {
   ]);
 });
 
+it('native function', function() {
+  compareStackTrace(createSingleLineSourceMap(), [
+    '[1].map(function(x) { throw new Error(x); });'
+  ], [
+    'Error: 1',
+    /\/.original\.js/,
+    /at Array\.map \(native\)/
+  ]);
+});
+
 it('function constructor', function() {
   compareStackTrace(createMultiLineSourceMap(), [
     'throw new Function(")");'


### PR DESCRIPTION
Trying to wrap a `CallSite` that is native leads to unexpected behaviour. In a particular case that I had, the lib tries to make a `XMLHttpRequest` for a file called `native array.js`, which doesn't actually exist.

I couldn't figure out the root cause, but this is the way I found to address it, and it resolved the problem fully without causing side effects.

<img width="457" alt="screen shot 2016-03-27 at 23 32 51" src="https://cloud.githubusercontent.com/assets/1757708/14068214/556d8e04-f474-11e5-98eb-eb58796177ad.png">
