### PR TITLE
Defensive coding to prevent out-of-range column

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -316,8 +316,9 @@ function wrapCallSite(frame) {
 
     // Fix position in Node where some (internal) code is prepended.
     // See https://github.com/evanw/node-source-map-support/issues/36
-    if (line === 1 && !isInBrowser() && !frame.isEval()) {
-      column -= 62;
+    var headerLength = 62;
+    if (line === 1 && column > headerLength && !isInBrowser() && !frame.isEval()) {
+      column -= headerLength;
     }
 
     var position = mapSourcePosition({


### PR DESCRIPTION
There may be errors on line 1 column 1 and those resulted in a column of -62 which threw an out-of-range error.

Our example was: "v8debug is not defined" which can occur when debugging a node app from WebStorm
