### PR TITLE
Don't attempt to download source maps for native code

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -310,7 +310,7 @@ function wrapCallSite(frame) {
   // passed to eval() ending in "//# sourceURL=..." will return the source file
   // from getScriptNameOrSourceURL() instead
   var source = frame.getFileName() || frame.getScriptNameOrSourceURL();
-  if (source) {
+  if (source && !frame.isNative()) {
     var line = frame.getLineNumber();
     var column = frame.getColumnNumber() - 1;
 


### PR DESCRIPTION
Prevents browser-source-map-support from making extraneous requests for native code like native messages.

![selection_051](https://cloud.githubusercontent.com/assets/1034455/16286876/2d2b6786-38ad-11e6-9145-361e2fa4d464.png)
