### PR TITLE
Use 'node' version when using Electron with nodeIntegration enabled

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -30,7 +30,7 @@ function isInBrowser() {
     return true;
   if (environment === "node")
     return false;
-  return ((typeof window !== 'undefined') && (typeof XMLHttpRequest === 'function'));
+  return ((typeof window !== 'undefined') && (typeof XMLHttpRequest === 'function') && !(window.require && window.module && window.process && window.process.type === "renderer"));
 }
 
 function hasGlobalProcessEventEmitter() {


### PR DESCRIPTION
When using Electron with `nodeIntegration` enabled, it's better to use native filesystem logic, rather than XHR. This adds detection for that.