### PR TITLE
Support relative paths in base64 source maps

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -136,7 +136,7 @@ retrieveMapHandlers.push(function(source) {
     // Support source map URL as a data url
     var rawData = sourceMappingURL.slice(sourceMappingURL.indexOf(',') + 1);
     sourceMapData = new Buffer(rawData, "base64").toString();
-    sourceMappingURL = null;
+    sourceMappingURL = source;
   } else {
     // Support source map URLs relative to the source URL
     sourceMappingURL = supportRelativeURL(source, sourceMappingURL);


### PR DESCRIPTION
Related to #100.

On NodeJS, as far as I can see, base64 source maps work nicely. However, the paths inside the stacktraces are relative to the compiled file, where I'd expect them to be absolute.

For example:

```
TypeError: log.error is not a function
    at ../src/file_reader.js:33:17
```

The reason seems to be that, when parsing a base64 URL, source-map-support has no URL for the source map itself. Thus, it stores `null` in the "url" field for the source map. Now, if the inlined source map contains a relative source path, this path can't be resolved as it is expected to be relative to the source map URL, which we don't have.

If my understanding is correct (and forgive my ignorance if it is not), relative paths in base64 source maps should be resolved relative to the file that contains the sourceMappingURL comment.

This pull request accomplishes just that, by storing the source-path for base64 source maps.

Note:
- the tests in `test.js` still pass
- I wasn't able to get the browser tests running (tested Safari, Chrome and Firefox, all on OS X)
- I haven't added a test for this. Can you help me with that part? `test.js` looks big and scary.
