### PR TITLE
Export a removeFromCache(filepath) function

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -49,6 +49,11 @@ function handlerExec(list) {
   };
 }
 
+// Removes a given file path from the source map cache.
+function removeFromCache(path) {
+  delete sourceMapCache[path];
+}
+
 var retrieveFile = handlerExec(retrieveFileHandlers);
 
 retrieveFileHandlers.push(function(path) {
@@ -424,6 +429,7 @@ exports.wrapCallSite = wrapCallSite;
 exports.getErrorSource = getErrorSource;
 exports.mapSourcePosition = mapSourcePosition;
 exports.retrieveSourceMap = retrieveSourceMap;
+exports.removeFromCache = removeFromCache;
 
 exports.install = function(options) {
   options = options || {};


### PR DESCRIPTION
`require('source-map-support').removeFromCache('path/to/foo.js')` will remove `path/to/foo.js` from the source map cache.

## Motivation

I use am using `babel-register`. At some point, my program notices that a file changes. So it calls

```
delete require.cache[require.resolve(filename)]
return require('filename');
```

## Expected behavior

Stack traces show lines/columns from the updated file

## Actual behavior

Stack traces still use the old source maps, so the locations are out of date

## How this helps

After this lands, I can update `babel-register` to call `removeFromCache(filename)` whenever it transforms a file. 