### PR TITLE
Remove sourceMappingURL comment

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -110,7 +110,6 @@ function retrieveSourceMapURL(source) {
 
   // Get the URL of the source map
   fileData = retrieveFile(source);
-  //        //# sourceMappingURL=foo.js.map                       /*# sourceMappingURL=foo.js.map */
   var re = /(?:\/\/[@#][ \t]+sourceMappingURL=([^\s'"]+?)[ \t]*$)|(?:\/\*[@#][ \t]+sourceMappingURL=([^\*]+?)[ \t]*(?:\*\/)[ \t]*$)/mg;
   // Keep executing the search to find the *last* sourceMappingURL to avoid
   // picking up sourceMappingURLs from comments, strings, etc.


### PR DESCRIPTION
A reason is from https://github.com/Jam3/devtool/issues/74, and recently [babel-register is updated source-map-support to ^0.4.2](https://github.com/babel/babel/commit/90f3f9049f05090343ffeb10bbc2634096bfd1c0), the `sourceMappingURL=foo.js.map` comment will broken babel-register on [Jam3/devtool](https://github.com/Jam3/devtool).
