### PR TITLE
Fix toString shim to be backwards compatible with node v4 and below 

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -270,6 +270,10 @@ function CallSiteToString() {
   var isMethodCall = !(this.isToplevel() || isConstructor);
   if (isMethodCall) {
     var typeName = this.getTypeName();
+    // Fixes shim to be backward compatable with Node v0 to v4
+    if (typeName === "[object Object]") {
+      typeName = "null";
+    }
     var methodName = this.getMethodName();
     if (functionName) {
       if (typeName && functionName.indexOf(typeName) != 0) {

--- a/test.js
+++ b/test.js
@@ -259,6 +259,21 @@ it('throw with empty source map', function() {
   ]);
 });
 
+it('throw in Timeout with empty source map', function(done) {
+  compareStdout(done, createEmptySourceMap(), [
+    'require("./source-map-support").install();',
+    'setTimeout(function () {',
+    '    throw new Error("this is the error")',
+    '})'
+  ], [
+    /\/.generated.js:3$/,
+    '    throw new Error("this is the error")',
+    /^          \^$/,
+    'Error: this is the error',
+    /^    at ((null)|(Timeout))\._onTimeout \((?:.*\/)?.generated.js:3:11\)$/
+  ]);
+});
+
 it('throw with source map with gap', function() {
   compareStackTrace(createSourceMapWithGap(), [
     'throw new Error("test");'


### PR DESCRIPTION
The toString shim does not print the typeName for CallSite, in node 4 and below the same as the native toString method.

Found this while running the node-tap test suite to add source map support into the stack traces of node-tap
tapjs/node-tap#329

File: t.js
```
 setTimeout(function () {
    throw { stack: new Error('this one').stack }
  })
  setTimeout(function () {
    throw new Error('not this one')
  }, 100)
```
File t.js - With Source Map Support
```
  require('./source-map-support').install();

  setTimeout(function () {
    throw { stack: new Error('this one').stack }
  })
  setTimeout(function () {
    throw new Error('not this one')
  }, 100)
```


## Node 0 - 4
```
[node-source-map-support[master ?*]]-> nvm use 0
Now using node v0.12.16 (npm v2.15.1)
[node-source-map-support[master ?*]]-> node t.js 

/Users/ben.mccurdy/Projects/node-source-map-support/t.js:2
    throw { stack: new Error('this one').stack }
                                        ^
Error: this one
    at null._onTimeout (/Users/ben.mccurdy/Projects/node-source-map-support/t.js:2:20)
    at Timer.listOnTimeout (timers.js:119:15)
```
With Source Map Support  
**Should be** - `null` has `[object Object]`
``` 
[node-source-map-support[master ?*]]-> nvm use 0
Now using node v0.12.16 (npm v2.15.1)
[node-source-map-support[master ?*]]-> node t.js 

/Users/ben.mccurdy/Projects/node-source-map-support/t.js:4
    throw { stack: new Error('this one').stack }
                   ^
Error: this one
    at [object Object]._onTimeout (/Users/ben.mccurdy/Projects/node-source-map-support/t.js:4:20)
    at Timer.listOnTimeout (timers.js:119:15)
```

    
## Node 6
```
[node-source-map-support[master ?*]]-> nvm use 6
Now using node v6.8.0 (npm v3.10.8)
[node-source-map-support[master ?*]]-> node t.js 

/Users/ben.mccurdy/Projects/node-source-map-support/t.js:2
    throw { stack: new Error('this one').stack }
    ^
Error: this one
    at Timeout._onTimeout (/Users/ben.mccurdy/Projects/node-source-map-support/t.js:2:20)
    at ontimeout (timers.js:365:14)
    at tryOnTimeout (timers.js:237:5)
    at Timer.listOnTimeout (timers.js:207:5)
```
 
```
[node-source-map-support[master ?*]]-> nvm use 6
Now using node v6.8.0 (npm v3.10.8)
[node-source-map-support[master ?*]]-> node t.js 

/Users/ben.mccurdy/Projects/node-source-map-support/t.js:4
    throw { stack: new Error('this one').stack }
                   ^
Error: this one
    at Timeout._onTimeout (/Users/ben.mccurdy/Projects/node-source-map-support/t.js:4:20)
    at ontimeout (timers.js:365:14)
    at tryOnTimeout (timers.js:237:5)
    at Timer.listOnTimeout (timers.js:207:5)
```