### PR TITLE
Fix webpack support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ browserify-test/script.js
 browserify-test/script.map
 header-test/script.js
 header-test/script.map
+webpack-test/compiled.js

--- a/build.js
+++ b/build.js
@@ -5,8 +5,9 @@ var path = require('path');
 var querystring = require('querystring');
 var child_process = require('child_process');
 
-var browserify = path.join('node_modules', '.bin', 'browserify');
-var coffee = path.join('node_modules', '.bin', 'coffee');
+var browserify = path.resolve(path.join('node_modules', '.bin', 'browserify'));
+var webpack = path.resolve(path.join('node_modules', '.bin', 'webpack'));
+var coffee = path.resolve(path.join('node_modules', '.bin', 'coffee'));
 
 function run(command, callback) {
   console.log(command);
@@ -70,4 +71,9 @@ run(coffee + ' --map --compile header-test/script.coffee', function(error) {
   if (error) throw error;
   var contents = fs.readFileSync('header-test/script.js', 'utf8');
   fs.writeFileSync('header-test/script.js', contents.replace(/\/\/# sourceMappingURL=.*/g, ''))
+});
+
+// Build the webpack test
+child_process.exec(webpack, {cwd: 'webpack-test'}, function(error) {
+  if (error) throw error;
 });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "browserify": "3.44.2",
     "coffee-script": "1.7.1",
     "http-server": "^0.8.5",
-    "mocha": "1.18.2"
+    "mocha": "1.18.2",
+    "webpack": "^1.13.3"
   },
   "repository": {
     "type": "git",

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -377,8 +377,13 @@ function getErrorSource(error) {
     var contents = fileContentsCache[source];
 
     // Support files on disk
-    if (!contents && fs.existsSync(source)) {
-      contents = fs.readFileSync(source, 'utf8');
+    try {
+      const fs = require('fs');
+      if (!contents && fs.existsSync(source)) {
+        contents = fs.readFileSync(source, 'utf8');
+      }
+    } catch (err) {
+      /* NOP */
     }
 
     // Format the line from the original source code like node does

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -1,6 +1,5 @@
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var path = require('path');
-var fs = require('fs');
 
 // Only install once if called multiple times
 var errorFormatterInstalled = false;
@@ -72,7 +71,7 @@ retrieveFileHandlers.push(function(path) {
 
     // Otherwise, use the filesystem
     else {
-      var contents = fs.readFileSync(path, 'utf8');
+      var contents = require('fs').readFileSync(path, 'utf8');
     }
   } catch (e) {
     var contents = null;
@@ -460,7 +459,12 @@ exports.install = function(options) {
 
   // Support runtime transpilers that include inline source maps
   if (options.hookRequire && !isInBrowser()) {
-    var Module = require('module');
+    var Module;
+    try {
+      Module = require('module');
+    } catch (err) {
+      // NOP: Loading in catch block to convert webpack error to warning.
+    }
     var $compile = Module.prototype._compile;
 
     if (!$compile.__sourceMapSupport) {

--- a/test.js
+++ b/test.js
@@ -180,7 +180,7 @@ it('eval', function() {
     'Error: test',
 
     // Before Node 4, `Object.eval`, after just `eval`.
-    /^    at (?:Object\.)?eval \(eval at <anonymous> \((?:.*\/)?line1\.js:1001:101\)/,
+    /^    at (?:Object\.)?eval \(eval at (<anonymous>|exports.test) \((?:.*\/)?line1\.js:1001:101\)/,
 
     /^    at Object\.exports\.test \((?:.*\/)?line1\.js:1001:101\)$/
   ]);
@@ -191,8 +191,8 @@ it('eval inside eval', function() {
     'eval("eval(\'throw new Error(\\"test\\")\')");'
   ], [
     'Error: test',
-    /^    at (?:Object\.)?eval \(eval at <anonymous> \(eval at <anonymous> \((?:.*\/)?line1\.js:1001:101\)/,
-    /^    at (?:Object\.)?eval \(eval at <anonymous> \((?:.*\/)?line1\.js:1001:101\)/,
+    /^    at (?:Object\.)?eval \(eval at (<anonymous>|exports.test) \(eval at (<anonymous>|exports.test) \((?:.*\/)?line1\.js:1001:101\)/,
+    /^    at (?:Object\.)?eval \(eval at (<anonymous>|exports.test) \((?:.*\/)?line1\.js:1001:101\)/,
     /^    at Object\.exports\.test \((?:.*\/)?line1\.js:1001:101\)$/
   ]);
 });
@@ -227,7 +227,7 @@ it('eval with sourceURL inside eval', function() {
   ], [
     'Error: test',
     /^    at (?:Object\.)?eval \(sourceURL\.js:1:7\)$/,
-    /^    at (?:Object\.)?eval \(eval at <anonymous> \((?:.*\/)?line1\.js:1001:101\)/,
+    /^    at (?:Object\.)?eval \(eval at (<anonymous>|exports.test) \((?:.*\/)?line1\.js:1001:101\)/,
     /^    at Object\.exports\.test \((?:.*\/)?line1\.js:1001:101\)$/
   ]);
 });

--- a/webpack-test/index.html
+++ b/webpack-test/index.html
@@ -1,0 +1,5 @@
+<p>
+Make sure to run build.js.
+This test should say either "Test failed" or "Test passed":
+</p>
+<script src="compiled.js"></script>

--- a/webpack-test/script.js
+++ b/webpack-test/script.js
@@ -1,0 +1,16 @@
+require('../').install();
+
+function foo() {
+  throw new Error('foo');
+}
+
+try {
+  foo();
+} catch (e) {
+  if (/\bscript\.js\b/.test(e.stack)) {
+    document.body.appendChild(document.createTextNode('Test passed'));
+  } else {
+    document.body.appendChild(document.createTextNode('Test failed'));
+    console.log(e.stack);
+  }
+}

--- a/webpack-test/webpack.config.js
+++ b/webpack-test/webpack.config.js
@@ -1,0 +1,12 @@
+var webpack = require('webpack');
+
+module.exports = {
+  entry: './script.js',
+  devtool: 'inline-source-map',
+  output: {
+    filename: 'compiled.js'
+  },
+  resolve: {
+    extensions: ['', '.js']
+  }
+};


### PR DESCRIPTION
This converts the webpack errors to warnings. Individual users may use the ignore plugin to further mute these warnings.