### PR TITLE
Improve syntax error

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -334,7 +334,17 @@ function wrapCallSite(frame) {
       column: column
     });
 
-    if (/source-map-support\/source-map-support\.js/.test(position.source)) {
+    var functionName = frame.getFunctionName(),
+        name = frame.getMethodName() || frame.getFunctionName();
+    if (/source-map-support\/source-map-support\.js/.test(position.source)
+        || /istanbul\/lib\/hook\.js/.test(position.source)
+        || /babel-register/.test(position.source)
+        || position.source === 'vm.js'
+        || (position.source === 'module.js'
+            && (/load$/.test(name)
+                || functionName === 'Module.require'
+                || /_compile/.test(name)
+                || /\.js$/.test(name)))) {
       return;
     }
 

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -333,6 +333,11 @@ function wrapCallSite(frame) {
       line: line,
       column: column
     });
+
+    if (/source-map-support\/source-map-support\.js/.test(position.source)) {
+      return;
+    }
+
     frame = cloneCallSite(frame);
     frame.getFileName = function() { return position.source; };
     frame.getLineNumber = function() { return position.line; };
@@ -363,7 +368,13 @@ function prepareStackTrace(error, stack) {
   }
 
   return error + stack.map(function(frame) {
-    return '\n    at ' + wrapCallSite(frame);
+    frame = wrapCallSite(frame);
+
+    if (frame) {
+      return '\n    at ' + frame;
+    } else {
+      return '';
+    }
   }).join('');
 }
 

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -484,12 +484,21 @@ exports.install = function(options) {
   if (options.hookRequire && !isInBrowser()) {
     var Module = require('module');
     var $compile = Module.prototype._compile;
-
     if (!$compile.__sourceMapSupport) {
       Module.prototype._compile = function(content, filename) {
         fileContentsCache[filename] = content;
         sourceMapCache[filename] = undefined;
-        return $compile.call(this, content, filename);
+        try {
+          return $compile.call(this, content, filename);
+        } catch (err) {
+          var relativePath = path.relative(process.cwd(), filename);
+
+          if (err instanceof SyntaxError) {
+            throw new SyntaxError(relativePath + ': ' + err.message);
+          } else {
+            throw err;
+          }
+        }
       };
 
       Module.prototype._compile.__sourceMapSupport = true;


### PR DESCRIPTION
This one might be a little more contentious, but this adds filtering to the stack frames for common runtime libraries. Effectively adds blackboxing to the stack traces.