### PR TITLE
swallow SJAX errors during in-browser translation

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -95,16 +95,20 @@ function retrieveSourceMapURL(source) {
   var fileData;
 
   if (isInBrowser()) {
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', source, false);
-    xhr.send(null);
-    fileData = xhr.readyState === 4 ? xhr.responseText : null;
+    try {
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', source, false);
+      xhr.send(null);
+      fileData = xhr.readyState === 4 ? xhr.responseText : null;
 
-    // Support providing a sourceMappingURL via the SourceMap header
-    var sourceMapHeader = xhr.getResponseHeader("SourceMap") ||
-                          xhr.getResponseHeader("X-SourceMap");
-    if (sourceMapHeader) {
-      return sourceMapHeader;
+      // Support providing a sourceMappingURL via the SourceMap header
+      var sourceMapHeader = xhr.getResponseHeader("SourceMap") ||
+                            xhr.getResponseHeader("X-SourceMap");
+      if (sourceMapHeader) {
+        return sourceMapHeader;
+      }
+    } catch (e) {
+      return null;
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/evanw/node-source-map-support/issues/161.

Similar to what @evanw did in https://github.com/evanw/node-source-map-support/commit/bbe8c603ab17418953629ff26b188a40a9015882, to prevent "translation" from failing when trying to load a resource from a different domain.