### PR TITLE
Run build.js before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "node build.js",
     "serve-tests": "http-server -p 1336",
+    "prepublish": "npm run build",
     "test": "mocha"
   },
   "dependencies": {


### PR DESCRIPTION
The issue in #164 is that the browser js version wasn't updated with the changes much needed in 0.6.4.

Be good to automate this before publishing the package.