### PR TITLE
Fix Uncaught Type Error

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -4,6 +4,10 @@ var path = require('path');
 var fs;
 try {
   fs = require('fs');
+  if (!fs.readFileSync || !fs.readFileSync) {
+    // fs doesn't have all methods we need
+    fs = null;
+  }
 } catch (err) {
   /* nop */
 }

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -4,7 +4,7 @@ var path = require('path');
 var fs;
 try {
   fs = require('fs');
-  if (!fs.readFileSync || !fs.readFileSync) {
+  if (!fs.existsSync || !fs.readFileSync) {
     // fs doesn't have all methods we need
     fs = null;
   }


### PR DESCRIPTION
Fixes https://github.com/evanw/node-source-map-support/issues/167

Since version 0.4.9, we require `fs` but it should fail if we are in
a browser. However, `browser-source-map-support.js` is bundled with
browserify which converts unsupported builtins to empty object. See
https://github.com/substack/node-browserify/blob/8f5ebbf505/lib/builtins.js#L12
This PR checks if required `fs` contains `readFileSync` which is part
of `fs` API.

Tests:
```
npm run build && npm run serve-tests
```
Then open http://127.0.0.1:1336/browser-test/