### PR TITLE
Update tests for Windows `\r\n` newline and `\` path delimeter

### DIFF
--- a/test.js
+++ b/test.js
@@ -92,7 +92,7 @@ function compareStackTrace(sourceMap, source, expected) {
     delete require.cache[require.resolve('./.generated')];
     require('./.generated').test();
   } catch (e) {
-    compareLines(e.stack.split('\n'), expected);
+    compareLines(e.stack.split(/\r\n|\n/), expected);
   }
   fs.unlinkSync('.generated.js');
   fs.unlinkSync('.generated.js.map');
@@ -105,7 +105,7 @@ function compareStackTrace(sourceMap, source, expected) {
     delete require.cache[require.resolve('./.generated')];
     require('./.generated').test();
   } catch (e) {
-    compareLines(e.stack.split('\n'), expected);
+    compareLines(e.stack.split(/\r\n|\n/), expected);
   }
   fs.unlinkSync('.generated.js');
 }
@@ -120,7 +120,7 @@ function compareStdout(done, sourceMap, source, expected) {
       compareLines(
         (stdout + stderr)
           .trim()
-          .split('\n')
+          .split(/\r\n|\n/)
           .filter(function (line) { return line !== '' }), // Empty lines are not relevant.
         expected
       );
@@ -139,7 +139,7 @@ it('normal throw', function() {
     'throw new Error("test");'
   ], [
     'Error: test',
-    /^    at Object\.exports\.test \((?:.*\/)?line1\.js:1001:101\)$/
+    /^    at Object\.exports\.test \((?:.*[/\\])?line1\.js:1001:101\)$/
   ]);
 });
 
@@ -151,8 +151,8 @@ it('throw inside function', function() {
     'foo();'
   ], [
     'Error: test',
-    /^    at foo \((?:.*\/)?line2\.js:1002:102\)$/,
-    /^    at Object\.exports\.test \((?:.*\/)?line4\.js:1004:104\)$/
+    /^    at foo \((?:.*[/\\])?line2\.js:1002:102\)$/,
+    /^    at Object\.exports\.test \((?:.*[/\\])?line4\.js:1004:104\)$/
   ]);
 });
 
@@ -167,9 +167,9 @@ it('throw inside function inside function', function() {
     'foo();'
   ], [
     'Error: test',
-    /^    at bar \((?:.*\/)?line3\.js:1003:103\)$/,
-    /^    at foo \((?:.*\/)?line5\.js:1005:105\)$/,
-    /^    at Object\.exports\.test \((?:.*\/)?line7\.js:1007:107\)$/
+    /^    at bar \((?:.*[/\\])?line3\.js:1003:103\)$/,
+    /^    at foo \((?:.*[/\\])?line5\.js:1005:105\)$/,
+    /^    at Object\.exports\.test \((?:.*[/\\])?line7\.js:1007:107\)$/
   ]);
 });
 
@@ -180,9 +180,9 @@ it('eval', function() {
     'Error: test',
 
     // Before Node 4, `Object.eval`, after just `eval`.
-    /^    at (?:Object\.)?eval \(eval at (<anonymous>|exports.test) \((?:.*\/)?line1\.js:1001:101\)/,
+    /^    at (?:Object\.)?eval \(eval at (<anonymous>|exports.test) \((?:.*[/\\])?line1\.js:1001:101\)/,
 
-    /^    at Object\.exports\.test \((?:.*\/)?line1\.js:1001:101\)$/
+    /^    at Object\.exports\.test \((?:.*[/\\])?line1\.js:1001:101\)$/
   ]);
 });
 
@@ -191,9 +191,9 @@ it('eval inside eval', function() {
     'eval("eval(\'throw new Error(\\"test\\")\')");'
   ], [
     'Error: test',
-    /^    at (?:Object\.)?eval \(eval at (<anonymous>|exports.test) \(eval at (<anonymous>|exports.test) \((?:.*\/)?line1\.js:1001:101\)/,
-    /^    at (?:Object\.)?eval \(eval at (<anonymous>|exports.test) \((?:.*\/)?line1\.js:1001:101\)/,
-    /^    at Object\.exports\.test \((?:.*\/)?line1\.js:1001:101\)$/
+    /^    at (?:Object\.)?eval \(eval at (<anonymous>|exports.test) \(eval at (<anonymous>|exports.test) \((?:.*[/\\])?line1\.js:1001:101\)/,
+    /^    at (?:Object\.)?eval \(eval at (<anonymous>|exports.test) \((?:.*[/\\])?line1\.js:1001:101\)/,
+    /^    at Object\.exports\.test \((?:.*[/\\])?line1\.js:1001:101\)$/
   ]);
 });
 
@@ -205,9 +205,9 @@ it('eval inside function', function() {
     'foo();'
   ], [
     'Error: test',
-    /^    at eval \(eval at foo \((?:.*\/)?line2\.js:1002:102\)/,
-    /^    at foo \((?:.*\/)?line2\.js:1002:102\)/,
-    /^    at Object\.exports\.test \((?:.*\/)?line4\.js:1004:104\)$/
+    /^    at eval \(eval at foo \((?:.*[/\\])?line2\.js:1002:102\)/,
+    /^    at foo \((?:.*[/\\])?line2\.js:1002:102\)/,
+    /^    at Object\.exports\.test \((?:.*[/\\])?line4\.js:1004:104\)$/
   ]);
 });
 
@@ -217,7 +217,7 @@ it('eval with sourceURL', function() {
   ], [
     'Error: test',
     /^    at (?:Object\.)?eval \(sourceURL\.js:1:7\)$/,
-    /^    at Object\.exports\.test \((?:.*\/)?line1\.js:1001:101\)$/
+    /^    at Object\.exports\.test \((?:.*[/\\])?line1\.js:1001:101\)$/
   ]);
 });
 
@@ -227,8 +227,8 @@ it('eval with sourceURL inside eval', function() {
   ], [
     'Error: test',
     /^    at (?:Object\.)?eval \(sourceURL\.js:1:7\)$/,
-    /^    at (?:Object\.)?eval \(eval at (<anonymous>|exports.test) \((?:.*\/)?line1\.js:1001:101\)/,
-    /^    at Object\.exports\.test \((?:.*\/)?line1\.js:1001:101\)$/
+    /^    at (?:Object\.)?eval \(eval at (<anonymous>|exports.test) \((?:.*[/\\])?line1\.js:1001:101\)/,
+    /^    at Object\.exports\.test \((?:.*[/\\])?line1\.js:1001:101\)$/
   ]);
 });
 
@@ -237,7 +237,7 @@ it('native function', function() {
     '[1].map(function(x) { throw new Error(x); });'
   ], [
     'Error: 1',
-    /\/.original\.js/,
+    /[/\\].original\.js/,
     /at Array\.map \(native\)/
   ]);
 });
@@ -255,7 +255,7 @@ it('throw with empty source map', function() {
     'throw new Error("test");'
   ], [
     'Error: test',
-    /^    at Object\.exports\.test \((?:.*\/)?.generated.js:1:34\)$/
+    /^    at Object\.exports\.test \((?:.*[/\\])?.generated.js:1:34\)$/
   ]);
 });
 
@@ -266,11 +266,11 @@ it('throw in Timeout with empty source map', function(done) {
     '    throw new Error("this is the error")',
     '})'
   ], [
-    /\/.generated.js:3$/,
+    /[/\\].generated.js:3$/,
     '    throw new Error("this is the error")',
     /^          \^$/,
     'Error: this is the error',
-    /^    at ((null)|(Timeout))\._onTimeout \((?:.*\/)?.generated.js:3:11\)$/
+    /^    at ((null)|(Timeout))\._onTimeout \((?:.*[/\\])?.generated.js:3:11\)$/
   ]);
 });
 
@@ -279,7 +279,7 @@ it('throw with source map with gap', function() {
     'throw new Error("test");'
   ], [
     'Error: test',
-    /^    at Object\.exports\.test \((?:.*\/)?.generated.js:1:34\)$/
+    /^    at Object\.exports\.test \((?:.*[/\\])?.generated.js:1:34\)$/
   ]);
 });
 
@@ -288,7 +288,7 @@ it('sourcesContent with data URL', function() {
     'throw new Error("test");'
   ], [
     'Error: test',
-    /^    at Object\.exports\.test \((?:.*\/)?original.js:1001:5\)$/
+    /^    at Object\.exports\.test \((?:.*[/\\])?original.js:1001:5\)$/
   ]);
 });
 
@@ -298,7 +298,7 @@ it('finds the last sourceMappingURL', function() {
     'throw new Error("test");'
   ], [
     'Error: test',
-    /^    at Object\.exports\.test \((?:.*\/)?original.js:1002:5\)$/
+    /^    at Object\.exports\.test \((?:.*[/\\])?original.js:1002:5\)$/
   ]);
 });
 
@@ -310,11 +310,11 @@ it('default options', function(done) {
     'process.nextTick(foo);',
     'process.nextTick(function() { process.exit(1); });'
   ], [
-    /\/.original\.js:1$/,
+    /[/\\].original\.js:1$/,
     'this is the original code',
     '^',
     'Error: this is the error',
-    /^    at foo \((?:.*\/)?.original\.js:1:1\)$/
+    /^    at foo \((?:.*[/\\])?.original\.js:1:1\)$/
   ]);
 });
 
@@ -325,11 +325,11 @@ it('handleUncaughtExceptions is true', function(done) {
     'require("./source-map-support").install({ handleUncaughtExceptions: true });',
     'process.nextTick(foo);'
   ], [
-    /\/.original\.js:1$/,
+    /[/\\].original\.js:1$/,
     'this is the original code',
     '^',
     'Error: this is the error',
-    /^    at foo \((?:.*\/)?.original\.js:1:1\)$/
+    /^    at foo \((?:.*[/\\])?.original\.js:1:1\)$/
   ]);
 });
 
@@ -340,7 +340,7 @@ it('handleUncaughtExceptions is false', function(done) {
     'require("./source-map-support").install({ handleUncaughtExceptions: false });',
     'process.nextTick(foo);'
   ], [
-    /\/.generated.js:2$/,
+    /[/\\].generated.js:2$/,
     'function foo() { throw new Error("this is the error"); }',
 
     // Before Node 4, the arrow points on the `new`, after on the
@@ -348,7 +348,7 @@ it('handleUncaughtExceptions is false', function(done) {
     /^                 (?:      )?\^$/,
 
     'Error: this is the error',
-    /^    at foo \((?:.*\/)?.original\.js:1:1\)$/
+    /^    at foo \((?:.*[/\\])?.original\.js:1:1\)$/
   ]);
 });
 
@@ -359,11 +359,11 @@ it('default options with empty source map', function(done) {
     'require("./source-map-support").install();',
     'process.nextTick(foo);'
   ], [
-    /\/.generated.js:2$/,
+    /[/\\].generated.js:2$/,
     'function foo() { throw new Error("this is the error"); }',
     /^                 (?:      )?\^$/,
     'Error: this is the error',
-    /^    at foo \((?:.*\/)?.generated.js:2:24\)$/
+    /^    at foo \((?:.*[/\\])?.generated.js:2:24\)$/
   ]);
 });
 
@@ -374,11 +374,11 @@ it('default options with source map with gap', function(done) {
     'require("./source-map-support").install();',
     'process.nextTick(foo);'
   ], [
-    /\/.generated.js:2$/,
+    /[/\\].generated.js:2$/,
     'function foo() { throw new Error("this is the error"); }',
     /^                 (?:      )?\^$/,
     'Error: this is the error',
-    /^    at foo \((?:.*\/)?.generated.js:2:24\)$/
+    /^    at foo \((?:.*[/\\])?.generated.js:2:24\)$/
   ]);
 });
 
@@ -391,7 +391,7 @@ it('specifically requested error source', function(done) {
     'process.on("uncaughtException", function (e) { console.log("SRC:" + sms.getErrorSource(e)); });',
     'process.nextTick(foo);'
   ], [
-    /^SRC:.*\/.original.js:1$/,
+    /^SRC:.*[/\\].original.js:1$/,
     'this is the original code',
     '^'
   ]);
@@ -405,11 +405,11 @@ it('sourcesContent', function(done) {
     'process.nextTick(foo);',
     'process.nextTick(function() { process.exit(1); });'
   ], [
-    /\/original\.js:1002$/,
+    /[/\\]original\.js:1002$/,
     '    line 2',
     '    ^',
     'Error: this is the error',
-    /^    at foo \((?:.*\/)?original\.js:1002:5\)$/
+    /^    at foo \((?:.*[/\\])?original\.js:1002:5\)$/
   ]);
 });
 
@@ -432,9 +432,9 @@ it('missing source maps should also be cached', function(done) {
     'process.nextTick(function() { console.log(count); });',
   ], [
     'Error: this is the error',
-    /^    at foo \((?:.*\/)?.generated.js:4:15\)$/,
+    /^    at foo \((?:.*[/\\])?.generated.js:4:15\)$/,
     'Error: this is the error',
-    /^    at foo \((?:.*\/)?.generated.js:4:15\)$/,
+    /^    at foo \((?:.*[/\\])?.generated.js:4:15\)$/,
     '1', // The retrieval should only be attempted once
   ]);
 });
@@ -465,9 +465,9 @@ it('should consult all retrieve source map providers', function(done) {
     'process.nextTick(function() { console.log(count); });',
   ], [
     'Error: this is the error',
-    /^    at foo \((?:.*\/)?original.js:1004:5\)$/,
+    /^    at foo \((?:.*[/\\])?original.js:1004:5\)$/,
     'Error: this is the error',
-    /^    at foo \((?:.*\/)?original.js:1004:5\)$/,
+    /^    at foo \((?:.*[/\\])?original.js:1004:5\)$/,
     '1', // The retrieval should only be attempted once
   ]);
 });
@@ -502,9 +502,9 @@ it('should allow for runtime inline source maps', function(done) {
     'require("./.generated.jss");',
   ], [
     'Error: this is the error',
-    /^    at foo \(.*\/original.js:1004:5\)$/,
+    /^    at foo \(.*[/\\]original.js:1004:5\)$/,
     'Error: this is the error',
-    /^    at foo \(.*\/original.js:1004:5\)$/,
+    /^    at foo \(.*[/\\]original.js:1004:5\)$/,
     '0', // The retrieval should only be attempted once
   ]);
 });
@@ -518,7 +518,7 @@ it('finds source maps with charset specified', function() {
   var source = [ 'throw new Error("test");' ];
   var expected = [
     'Error: test',
-    /^    at Object\.exports\.test \((?:.*\/)?line1\.js:1001:101\)$/
+    /^    at Object\.exports\.test \((?:.*[/\\])?line1\.js:1001:101\)$/
   ];
 
   fs.writeFileSync('.generated.js', 'exports.test = function() {' +
@@ -528,7 +528,7 @@ it('finds source maps with charset specified', function() {
     delete require.cache[require.resolve('./.generated')];
     require('./.generated').test();
   } catch (e) {
-    compareLines(e.stack.split('\n'), expected);
+    compareLines(e.stack.split(/\r\n|\n/), expected);
   }
   fs.unlinkSync('.generated.js');
 });
@@ -542,7 +542,7 @@ it('allows code/comments after sourceMappingURL', function() {
   var source = [ 'throw new Error("test");' ];
   var expected = [
     'Error: test',
-    /^    at Object\.exports\.test \((?:.*\/)?line1\.js:1001:101\)$/
+    /^    at Object\.exports\.test \((?:.*[/\\])?line1\.js:1001:101\)$/
   ];
 
   fs.writeFileSync('.generated.js', 'exports.test = function() {' +
@@ -553,7 +553,7 @@ it('allows code/comments after sourceMappingURL', function() {
     delete require.cache[require.resolve('./.generated')];
     require('./.generated').test();
   } catch (e) {
-    compareLines(e.stack.split('\n'), expected);
+    compareLines(e.stack.split(/\r\n|\n/), expected);
   }
   fs.unlinkSync('.generated.js');
 });


### PR DESCRIPTION
All 28 Mocha tests were failing, and now pass.
Resolves Issue #89, and updates the stale PR #90.
