### PR TITLE
Issue 141: Bumping source-map to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "source-map": "^0.5.3"
+    "source-map": "^0.5.6"
   },
   "devDependencies": {
     "browserify": "3.44.2",


### PR DESCRIPTION
Updates source-map to v0.5.6 to resolve issue #141.
Tests still pass, except the known problem with browserify (PR #66).
