### PR TITLE
fix: browser regression from #169 when getResponseHeader throws

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -113,7 +113,6 @@ function retrieveSourceMapURL(source) {
          return sourceMapHeader;
        }
      } catch (e) {
-       return null;
      }
   }
 


### PR DESCRIPTION
instead of return null, keep looking for sourcemap