### PR TITLE
Added webpack-test to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ amd-test/
 browser-test/
 browserify-test/
 header-test/
+webpack-test/


### PR DESCRIPTION
The compiled output of the webpack test is about 468k on disk. It looks like its inclusion in the package was an oversight, so I figured it couldn't hurt to try to remove it.