### PR TITLE
Cleanup npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,7 @@ browser-test/
 browserify-test/
 header-test/
 webpack-test/
+.npmignore
+.travis.yml
+build.js
+test.js


### PR DESCRIPTION
As far as I can see, the following files are not needed to run the package:
- .npmignore
- .travis.yml
- build.js
- test.js