### PR TITLE
Be resilient against readFileSync failures

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -80,7 +80,11 @@ retrieveFileHandlers.push(function(path) {
     }
   } else if (fs.existsSync(path)) {
     // Otherwise, use the filesystem
-    contents = fs.readFileSync(path, 'utf8');
+    try {
+      contents = fs.readFileSync(path, 'utf8');
+    } catch (er) {
+      contents = '';
+    }
   }
 
   return fileContentsCache[path] = contents;
@@ -388,7 +392,11 @@ function getErrorSource(error) {
 
     // Support files on disk
     if (!contents && fs && fs.existsSync(source)) {
-      contents = fs.readFileSync(source, 'utf8');
+      try {
+        contents = fs.readFileSync(source, 'utf8');
+      } catch (er) {
+        contents = '';
+      }
     }
 
     // Format the line from the original source code like node does

--- a/test.js
+++ b/test.js
@@ -143,6 +143,28 @@ it('normal throw', function() {
   ]);
 });
 
+/* The following test duplicates some of the code in
+ * `normal throw` but triggers file read failure.
+ */
+it('fs.readFileSync failure', function() {
+  compareStackTrace(createMultiLineSourceMap(), [
+    'var fs = require("fs");',
+    'var rfs = fs.readFileSync;',
+    'fs.readFileSync = function() {',
+    '  throw new Error("no rfs for you");',
+    '};',
+    'try {',
+    '  throw new Error("test");',
+    '} finally {',
+    '  fs.readFileSync = rfs;',
+    '}'
+  ], [
+    'Error: test',
+    /^    at Object\.exports\.test \((?:.*[/\\])?line7\.js:1007:107\)$/
+  ]);
+});
+
+
 it('throw inside function', function() {
   compareStackTrace(createMultiLineSourceMap(), [
     'function foo() {',


### PR DESCRIPTION
Generating a call stack when using this library can trigger a call to
fs.readFileSync.  That call can sometimes fail, resulting in a very
confusing stack trace (or none at all, which is even more confusing).

This patch wraps calls to fs.readFileSync() in a try/catch.  If the read
fails, then the file contents are omitted, but this is far better than
total failure.

Tracking down this one was fun, as you can probably imagine :)
