### PR TITLE
Add browser field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Fixes stack traces for files with source maps",
   "version": "0.5.0",
   "main": "./source-map-support.js",
+  "browser": "./browser-source-map-support.js",
   "scripts": {
     "build": "node build.js",
     "serve-tests": "http-server -p 1336",


### PR DESCRIPTION
Webpack and Browserify both automatically check for a `browser` property in `package.json` when resolving external module paths:

https://webpack.js.org/configuration/resolve/#resolve-mainfields
https://github.com/browserify/browserify-handbook#browser-field

This PR ensures that the correct version will be used when bundling via webpack or Browserify.