### PR TITLE
Add support for proper handling of file protocol (in windows)

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -64,7 +64,7 @@ var retrieveFile = handlerExec(retrieveFileHandlers);
 retrieveFileHandlers.push(function(path) {
   // Trim the path to make sure there is no extra whitespace.
   path = path.trim();
-  if (path.startsWith('file:')) {
+  if (/^file:/.test(path)) {
     // existsSync/readFileSync can't handle file protocol, but once stripped, it works
     path = path.replace(/file:\/\/(\w:\\|\/)/, '');
   }

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -64,6 +64,10 @@ var retrieveFile = handlerExec(retrieveFileHandlers);
 retrieveFileHandlers.push(function(path) {
   // Trim the path to make sure there is no extra whitespace.
   path = path.trim();
+  if (path.startsWith('file:')) {
+    // existsSync/readFileSync can't handle file protocol, but once stripped, it works
+    path = path.replace(/file:\/\/(\w:\\|\/)/, '');
+  }
   if (path in fileContentsCache) {
     return fileContentsCache[path];
   }
@@ -91,12 +95,18 @@ retrieveFileHandlers.push(function(path) {
 });
 
 // Support URLs relative to a directory, but be careful about a protocol prefix
-// in case we are in the browser (i.e. directories may start with "http://")
+// in case we are in the browser (i.e. directories may start with "http://" or "file:///")
 function supportRelativeURL(file, url) {
   if (!file) return url;
   var dir = path.dirname(file);
   var match = /^\w+:\/\/[^\/]*/.exec(dir);
   var protocol = match ? match[0] : '';
+  var startPath = dir.slice(protocol.length);
+  if (protocol && /^\/\w\:/.test(startPath)) {
+    // handle file:///C:/ paths
+    protocol += '/';
+    return protocol + path.resolve(dir.slice(protocol.length), url).replace(/\\/g, '/');
+  }
   return protocol + path.resolve(dir.slice(protocol.length), url);
 }
 


### PR DESCRIPTION
Trying to debug node with DevTools with transpiled code on Windows is a mess. First, this is *not* the fault of node-source-map-support at all. It works great on windows on its own. But the hacks necessary to get this to work do break node-source-map-support.

The basic problem is this: Node uses OS file paths, and DevTools doesn't understand OS file paths, it only understands URIs (including file:// URIs). So to actually get DevTools to comprehend source maps (so that you can set breakpoints and step through source code), you need to map your node modules to file:// URIs, so that DevTools can then do the relative path lookups to find your source maps/code. This means your modules that registered in Node need to have filenames like "file:///C:/dev/my-module.js". And this is where the most critical issue in node-source-map-support comes in: `supportRelativeURL` will break that up into "file://" and "/C:/dev/my-module.js" which `path.resolve` incorrectly computes to something like "C:/C:/dev/module.js" (plus relative path). And because `supportRelativeURL` can't be replaced by options, I think this actually needs to be fixed in node-source-map-support.

I figured while I was fixing this, I would also fix the default retrieveFileHandler to be able to properly handle file:// support (since existsSync/readFileSync doesn't on its own). Although technically you can provide a custom file handler to override this, as a user.

If you are wondering how I map node modules to file:// URLs, in our application I have been monkey patching the `vm.runInThisContext` function:
```
  vm.runInThisContext = function(wrapper, options) {
    if (options && options.filename && options.filename.match(/\.js$/) && options.filename.indexOf('node_modules') == -1) {
      options.filename = 'file:///' + options.filename.replace(/\\/g, '/')
    }
    return runInThisContext.apply(this, arguments)
  }
```
I suppose bonus support would be to actually add an option that does this for the user.

With this all in place, I now have the complete zen harmony of perfectly source-mapped modules in my stack traces *and* dev tools. I can set breakpoints in source code, I can click on stack traces, and go to the right source in dev tools. It all works beautifully.

I haven't done anything with tests. I wasn't sure how much of this would be willing to be accepted. Let me know if you want anything else for this PR.