### PR TITLE
Fix handling of file:/// paths on *nix systems

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -66,7 +66,11 @@ retrieveFileHandlers.push(function(path) {
   path = path.trim();
   if (/^file:/.test(path)) {
     // existsSync/readFileSync can't handle file protocol, but once stripped, it works
-    path = path.replace(/file:\/\/(\w:\\|\/)/, '');
+    path = path.replace(/file:\/\/\/(\w:)?/, function(protocol, drive) {
+      return drive ?
+        '' : // file:///C:/dir/file -> C:/dir/file
+        '/'; // file:///root-dir/file -> /root-dir/file
+    });
   }
   if (path in fileContentsCache) {
     return fileContentsCache[path];


### PR DESCRIPTION
It turns out the last PR didn't quite solve file:// protocol handling in *nix systems, as there some tricky differences between file URLs on windows and unix. In particular, a windows URL like "file:///C:/dir/file" needs to be stripped of all three slashes to "C:/dir/file", but a unix URL like "file:///root-dir/file" needs to be stripped of two slashes to "/dir/file". The easy solution would be to use node's `URL` constructor, and pass the `URL` instance to `existsSync`/`readFileSync`, but that is not supported on older node versions, which I think this project is committed to supporting. The solution I provided isn't pretty, but seem to work across both styles of file URLs, and is a relatively minor change.

This issue on unix is as problematic as on windows. At least in unix, dev tools will properly infer a URL from OS paths so source maps work in dev tools. However, clicking on stack traces doesn't take you to the correct mode in dev tools unless you attach full file:// protocol URLs to node modules.