### PR TITLE
Fixes #207: Synchronously log error on exit

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -429,11 +429,10 @@ function printErrorAndExit (error) {
   var source = getErrorSource(error);
 
   if (source) {
-    console.error();
-    console.error(source);
+    fs.writeSync(2, "\n" + source + "\n");
   }
 
-  console.error(error.stack);
+  fs.writeSync(2, error.stack + "\n");
   process.exit(1);
 }
 


### PR DESCRIPTION
Calling `process.exit(1)` exits the process immediately and might prevent writes from completing as explained in [process.exit documentation](https://nodejs.org/api/process.html#process_process_exit_code). Setting the `exitCode` property instead lets pending events in the event loop run (like writing to stderr) but prevents any additional work from being scheduled. This is the recommended way to exit Node processes.