### PR TITLE
Add `resetRetrieveHandlers` to avoid memory leak

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -455,6 +455,9 @@ function shimEmitUncaughtException () {
   };
 }
 
+var originalRetrieveFileHandlers = retrieveFileHandlers.slice(0);
+var originalRetrieveMapHandlers = retrieveMapHandlers.slice(0);
+
 exports.wrapCallSite = wrapCallSite;
 exports.getErrorSource = getErrorSource;
 exports.mapSourcePosition = mapSourcePosition;
@@ -540,3 +543,11 @@ exports.install = function(options) {
     }
   }
 };
+
+exports.resetRetrieveHandlers = function() {
+  retrieveFileHandlers.length = 0;
+  retrieveMapHandlers.length = 0;
+
+  retrieveFileHandlers = originalRetrieveFileHandlers.slice(0);
+  retrieveMapHandlers = originalRetrieveMapHandlers.slice(0);
+}


### PR DESCRIPTION
I haven't added docs as I don't think this is the correct way to do this...

Background:

Jest has a CLI flag called `--detectLeaks` which tries to sniff out memory leaks in your test suite.
We discovered today that Jest itself seems to be leaking, and bisected it to https://github.com/facebook/jest/commit/3341d162715679a596bfbbec8a7a5c5676c5f1b7. After fiddling a bit with it, I discovered that if I remove the whole `retrieveSourceMap` function from the options passed to `install`, it doesn't complain about a leak. Just making the function be empty and always return `null` still reported a leak.

The only way I was able to find that lets us keep using `retrieveSourceMap` but not leak was to add the function added in this PR.

It feels really hacky, so I'd love to find a way forward without needing this PR. 🙏

If you wanna mess around with fixes, to test in Jest just clone the repo, run `yarn` (followed by `yarn watch` if you wanna make changes to Jest's code base and not just in `node_modules`) and run `./jest --detectLeaks diff --no-cache`. The diff I applied in Jest's code base to call the function added in this PR is this:

```diff
diff --git i/packages/jest-jasmine2/src/index.js w/packages/jest-jasmine2/src/index.js
index 9f144d34..e872c22f 100644
--- i/packages/jest-jasmine2/src/index.js
+++ w/packages/jest-jasmine2/src/index.js
@@ -161,9 +161,14 @@ async function jasmine2(
 
   runtime.requireModule(testPath);
   await env.execute();
-  return reporter
-    .getResults()
-    .then(results => addSnapshotData(results, snapshotState));
+
+  try {
+    const results = await reporter.getResults();
+
+    return addSnapshotData(results, snapshotState);
+  } finally {
+    sourcemapSupport.resetRetrieveHandlers();
+  }
 }
 
 const addSnapshotData = (results, snapshotState) => {
``` 