### PR TITLE
Use file protocol for stack traces in windows

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -365,7 +365,13 @@ function wrapCallSite(frame) {
     frame.getFileName = function() { return position.source; };
     frame.getLineNumber = function() { return position.line; };
     frame.getColumnNumber = function() { return position.column + 1; };
-    frame.getScriptNameOrSourceURL = function() { return position.source; };
+    frame.getScriptNameOrSourceURL = function() {
+      if (!/^\w+:\/\//.test(position.source) && /^\w\:\\/.test(position.source)) {
+        // if it a windows path, need to add file:///
+        return 'file:///' + position.source.replace(/\\/g, '/');
+      }
+      return position.source;
+    };
     return frame;
   }
 


### PR DESCRIPTION
Chrome 66's dev tools changed its handling of windows file paths. It now seems to interpret windows file paths properly so that relative paths work properly. It is no longer necessary to relabel node modules with file: URIs to get debugging to work wit source maps. In fact, labeling modules with file: URIs no longer works, Chrome 66 breaks source map debugging in that case. This is still good news, since you don't need to hack the module loader just to get debugging to work. However, there is a caveat. Chrome 66 does *not* interpret windows file paths in stack traces as URIs (that can be clicked and take you to the source). In order for that to work, you need to convert the file paths to file: URIs in the stack trace printing. Fortunately that is a lot easier than some of the former hacks. This pull request adds this conversion of windows file paths to file URIs in stack traces, restoring full clickable paths directly to source.

There are alternate ways this could be done. I am currently doing this by replacing `prepareStackTrace` and calling `wrapCallSite`, without any changes to this package, but this a bit of a hassle. Also, this could be optional behavior; if you want this behavior to be driven by an optional/flag (defaulting to enabled or disabled), I could certainly add that.