### PR TITLE
Fix exception not printed when debugging

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -430,11 +430,17 @@ function getErrorSource(error) {
 function printErrorAndExit (error) {
   var source = getErrorSource(error);
 
-  if (source) {
-    fs.writeSync(2, "\n" + source + "\n");
+  // Ensure error is printed synchronously and not truncated
+  if (process.stderr._handle && process.stderr._handle.setBlocking) {
+    process.stderr._handle.setBlocking(true);
   }
 
-  fs.writeSync(2, error.stack + "\n");
+  if (source) {
+    console.error();
+    console.error(source);
+  }
+
+  console.error(error.stack);
   process.exit(1);
 }
 


### PR DESCRIPTION
This is based on my comment in PR #208 which caused exceptions not to be printed to the console when debugging (eg. using Chromium or VS Code). I've also simplified the code a bit.