### PR TITLE
Catch XHR errors

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -80,13 +80,16 @@ retrieveFileHandlers.push(function(path) {
 
   var contents = null;
   if (!fs) {
-    // Use SJAX if we are in the browser
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', path, false);
-    xhr.send(null);
-    var contents = null
-    if (xhr.readyState === 4 && xhr.status === 200) {
-      contents = xhr.responseText
+    try {
+      // Use SJAX if we are in the browser
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', path, /** async */ false);
+      xhr.send(null);
+      if (xhr.readyState === 4 && xhr.status === 200) {
+        contents = xhr.responseText;
+      }
+    } catch (er) {
+      contents = '';
     }
   } else if (fs.existsSync(path)) {
     // Otherwise, use the filesystem

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -78,9 +78,9 @@ retrieveFileHandlers.push(function(path) {
     return fileContentsCache[path];
   }
 
-  var contents = null;
-  if (!fs) {
-    try {
+  var contents = '';
+  try {
+    if (!fs) {
       // Use SJAX if we are in the browser
       var xhr = new XMLHttpRequest();
       xhr.open('GET', path, /** async */ false);
@@ -88,16 +88,12 @@ retrieveFileHandlers.push(function(path) {
       if (xhr.readyState === 4 && xhr.status === 200) {
         contents = xhr.responseText;
       }
-    } catch (er) {
-      contents = '';
-    }
-  } else if (fs.existsSync(path)) {
-    // Otherwise, use the filesystem
-    try {
+    } else if (fs.existsSync(path)) {
+      // Otherwise, use the filesystem
       contents = fs.readFileSync(path, 'utf8');
-    } catch (er) {
-      contents = '';
     }
+  } catch (er) {
+    /* ignore any errors */
   }
 
   return fileContentsCache[path] = contents;


### PR DESCRIPTION
When the XHR request throws an error (e.g. in case of CORS issues), it is now catched properly. Needed to fix weird Karma/Jasmine issues in Angular CLI projects.

Closes https://github.com/angular/angular-cli/issues/7296.