### PR TITLE
Check if .map.originalPositionFor is a function before executing

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -210,7 +210,7 @@ function mapSourcePosition(position) {
   }
 
   // Resolve the source URL relative to the URL of the source map
-  if (sourceMap && sourceMap.map) {
+  if (sourceMap && sourceMap.map && typeof sourceMap.map.originalPositionFor === 'function') {
     var originalPosition = sourceMap.map.originalPositionFor(position);
 
     // Only return the original position if a matching line was found. If no


### PR DESCRIPTION
Hardens the structural typecheck performed in `mapSourcePosition` before executing `originalPositionFor` methods on `sourceMap.map` objects. 

This addresses a bug I encountered with `electron-updater` while working on https://github.com/meetalva/alva/, where `Promise` values somehow end up in `sourceMap.map`, causing the app to crash with stack traces like this.

```
-/app.asar/node_modules/source-map-support/source-map-support.js:214
    var originalPosition = sourceMap.map.originalPositionFor(position);
                                         ^

TypeError: sourceMap.map.originalPositionFor is not a function
    at mapSourcePosition (-/app.asar/node_modules/source-map-support/source-map-support.js:214:42)
    at wrapCallSite (-/app.asar/node_modules/source-map-support/source-map-support.js:358:20)
    at -/app.asar/node_modules/source-map-support/source-map-support.js:395:26
    at Array.map (<anonymous>)
    at Function.prepareStackTrace (-/app.asar/node_modules/source-map-support/source-map-support.js:394:24)
    at process.emit (-/app.asar/node_modules/source-map-support/source-map-support.js:453:52)
    at process._fatalException (internal/bootstrap/node.js:488:27)
```

Unfortunately I don't know how this happens exactly. Debugging this proves rather hard due to the exception only being raised when starting the built `electron-builder` application.