### PR TITLE
Pinned source-map dependency to ~0.6.0 range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "dev": true,
       "requires": {
         "jsonparse": "0.0.5",
-        "through": "2.3.8"
+        "through": ">=2.2.7 <3"
       }
     },
     "acorn": {
@@ -32,9 +32,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -49,8 +49,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "arr-diff": {
@@ -59,7 +59,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -89,7 +89,7 @@
       "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.3"
       }
     },
     "async": {
@@ -134,7 +134,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -144,9 +144,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "browser-pack": {
@@ -155,9 +155,9 @@
       "integrity": "sha1-XRxSf1bFgmd0EcTbKhKGSP9r8VA=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.6.4",
-        "combine-source-map": "0.3.0",
-        "through": "2.3.8"
+        "JSONStream": "~0.6.4",
+        "combine-source-map": "~0.3.0",
+        "through": "~2.3.4"
       },
       "dependencies": {
         "JSONStream": {
@@ -167,7 +167,7 @@
           "dev": true,
           "requires": {
             "jsonparse": "0.0.5",
-            "through": "2.2.7"
+            "through": "~2.2.7"
           },
           "dependencies": {
             "through": {
@@ -195,51 +195,51 @@
       "integrity": "sha1-/6J4jQboBz/9c02Uw64nLKPdYwo=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.7.4",
-        "assert": "1.1.2",
-        "browser-pack": "2.0.1",
-        "browser-resolve": "1.2.4",
-        "browserify-zlib": "0.1.4",
-        "buffer": "2.1.13",
-        "builtins": "0.0.7",
+        "JSONStream": "~0.7.1",
+        "assert": "~1.1.0",
+        "browser-pack": "~2.0.0",
+        "browser-resolve": "~1.2.1",
+        "browserify-zlib": "~0.1.2",
+        "buffer": "~2.1.4",
+        "builtins": "~0.0.3",
         "commondir": "0.0.1",
-        "concat-stream": "1.4.10",
-        "console-browserify": "1.0.3",
-        "constants-browserify": "0.0.1",
-        "crypto-browserify": "1.0.9",
-        "deep-equal": "0.1.2",
-        "defined": "0.0.0",
-        "deps-sort": "0.1.2",
-        "derequire": "0.8.0",
-        "domain-browser": "1.1.7",
-        "duplexer": "0.1.1",
-        "events": "1.0.2",
-        "glob": "3.2.11",
-        "http-browserify": "1.3.2",
-        "https-browserify": "0.0.1",
-        "inherits": "2.0.3",
-        "insert-module-globals": "5.0.1",
-        "module-deps": "1.10.0",
-        "os-browserify": "0.1.2",
-        "parents": "0.0.3",
-        "path-browserify": "0.0.0",
-        "punycode": "1.2.4",
+        "concat-stream": "~1.4.1",
+        "console-browserify": "~1.0.1",
+        "constants-browserify": "~0.0.1",
+        "crypto-browserify": "~1.0.9",
+        "deep-equal": "~0.1.0",
+        "defined": "~0.0.0",
+        "deps-sort": "~0.1.1",
+        "derequire": "~0.8.0",
+        "domain-browser": "~1.1.0",
+        "duplexer": "~0.1.1",
+        "events": "~1.0.0",
+        "glob": "~3.2.8",
+        "http-browserify": "~1.3.1",
+        "https-browserify": "~0.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "~5.0.1",
+        "module-deps": "~1.10.0",
+        "os-browserify": "~0.1.1",
+        "parents": "~0.0.1",
+        "path-browserify": "~0.0.0",
+        "punycode": "~1.2.3",
         "querystring-es3": "0.2.0",
-        "resolve": "0.6.3",
+        "resolve": "~0.6.1",
         "shallow-copy": "0.0.1",
-        "shell-quote": "0.0.1",
-        "stream-browserify": "0.1.3",
-        "stream-combiner": "0.0.4",
-        "string_decoder": "0.0.1",
+        "shell-quote": "~0.0.1",
+        "stream-browserify": "~0.1.0",
+        "stream-combiner": "~0.0.2",
+        "string_decoder": "~0.0.0",
         "subarg": "0.0.1",
-        "syntax-error": "1.1.6",
-        "through2": "0.4.2",
-        "timers-browserify": "1.0.3",
-        "tty-browserify": "0.0.0",
-        "umd": "2.0.0",
-        "url": "0.10.3",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4"
+        "syntax-error": "~1.1.0",
+        "through2": "~0.4.1",
+        "timers-browserify": "~1.0.1",
+        "tty-browserify": "~0.0.0",
+        "umd": "~2.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.1",
+        "vm-browserify": "~0.0.1"
       }
     },
     "browserify-aes": {
@@ -248,7 +248,7 @@
       "integrity": "sha1-BnFJtmjfMcS1hTPgLQHoBthgjiw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "browserify-zlib": {
@@ -257,7 +257,7 @@
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
-        "pako": "0.2.9"
+        "pako": "~0.2.0"
       }
     },
     "buffer": {
@@ -266,8 +266,8 @@
       "integrity": "sha1-yIg46/efMLi0pwd4hHC+qKYsI1U=",
       "dev": true,
       "requires": {
-        "base64-js": "0.0.8",
-        "ieee754": "1.1.8"
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
       }
     },
     "buffer-from": {
@@ -305,8 +305,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chokidar": {
@@ -315,15 +315,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.2",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "cliui": {
@@ -332,8 +332,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -357,7 +357,7 @@
       "integrity": "sha1-YplqhheAx15tUGnROCJyO3NAS/w=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.3.5"
+        "mkdirp": "~0.3.5"
       }
     },
     "colors": {
@@ -372,9 +372,9 @@
       "integrity": "sha1-2edPWT2c1DgHMSy12EbUUe+qnrc=",
       "dev": true,
       "requires": {
-        "convert-source-map": "0.3.5",
-        "inline-source-map": "0.3.1",
-        "source-map": "0.1.43"
+        "convert-source-map": "~0.3.0",
+        "inline-source-map": "~0.3.0",
+        "source-map": "~0.1.31"
       },
       "dependencies": {
         "source-map": {
@@ -383,7 +383,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -412,9 +412,9 @@
       "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "1.1.14",
-        "typedarray": "0.0.6"
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.9",
+        "typedarray": "~0.0.5"
       }
     },
     "console-browserify": {
@@ -492,9 +492,9 @@
       "integrity": "sha1-2qL7YUoXyWN9gB4vVTOa43DzYRo=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.6.4",
-        "minimist": "0.0.10",
-        "through": "2.3.8"
+        "JSONStream": "~0.6.4",
+        "minimist": "~0.0.1",
+        "through": "~2.3.4"
       },
       "dependencies": {
         "JSONStream": {
@@ -504,7 +504,7 @@
           "dev": true,
           "requires": {
             "jsonparse": "0.0.5",
-            "through": "2.2.7"
+            "through": "~2.2.7"
           },
           "dependencies": {
             "through": {
@@ -523,9 +523,9 @@
       "integrity": "sha1-wffx2izt5Ere3gRzePA/RE6cTA0=",
       "dev": true,
       "requires": {
-        "esprima-fb": "3001.1.0-dev-harmony-fb",
-        "esrefactor": "0.1.0",
-        "estraverse": "1.5.1"
+        "esprima-fb": "^3001.1.0-dev-harmony-fb",
+        "esrefactor": "~0.1.0",
+        "estraverse": "~1.5.0"
       }
     },
     "detective": {
@@ -534,7 +534,7 @@
       "integrity": "sha1-d3gkRKt1K4jKG+Lp0KA5Xx2iXu0=",
       "dev": true,
       "requires": {
-        "escodegen": "1.1.0",
+        "escodegen": "~1.1.0",
         "esprima-fb": "3001.1.0-dev-harmony-fb"
       }
     },
@@ -562,9 +562,9 @@
       "integrity": "sha1-y6KqvqRrjNl/AWCFlxO3DSjmoCI=",
       "dev": true,
       "requires": {
-        "he": "0.5.0",
-        "mime": "1.3.6",
-        "minimist": "1.2.0",
+        "he": "^0.5.0",
+        "mime": "^1.2.11",
+        "minimist": "^1.1.0",
         "url-join": "0.0.1"
       },
       "dependencies": {
@@ -588,9 +588,9 @@
       "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.2.0",
-        "tapable": "0.1.10"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.2.0",
+        "tapable": "^0.1.8"
       },
       "dependencies": {
         "graceful-fs": {
@@ -613,7 +613,7 @@
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "dev": true,
       "requires": {
-        "prr": "0.0.0"
+        "prr": "~0.0.0"
       }
     },
     "escodegen": {
@@ -622,10 +622,10 @@
       "integrity": "sha1-xmOSP24gqtSNDA+knzHG1PSTYM8=",
       "dev": true,
       "requires": {
-        "esprima": "1.0.4",
-        "estraverse": "1.5.1",
-        "esutils": "1.0.0",
-        "source-map": "0.1.43"
+        "esprima": "~1.0.4",
+        "estraverse": "~1.5.0",
+        "esutils": "~1.0.0",
+        "source-map": "~0.1.30"
       },
       "dependencies": {
         "esprima": {
@@ -641,7 +641,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -652,7 +652,7 @@
       "integrity": "sha1-QYx6CvynIdr+ZZGT/Zhig+dGU48=",
       "dev": true,
       "requires": {
-        "estraverse": "1.5.1"
+        "estraverse": ">= 0.0.2"
       }
     },
     "esprima-fb": {
@@ -667,9 +667,9 @@
       "integrity": "sha1-0UJ5WigjOauB6Ta1t6IbEb8ZexM=",
       "dev": true,
       "requires": {
-        "escope": "0.0.16",
-        "esprima": "1.0.4",
-        "estraverse": "0.0.4"
+        "escope": "~0.0.13",
+        "esprima": "~1.0.2",
+        "estraverse": "~0.0.4"
       },
       "dependencies": {
         "esprima": {
@@ -716,7 +716,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -725,7 +725,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "extglob": {
@@ -734,7 +734,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "filename-regex": {
@@ -749,11 +749,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "for-in": {
@@ -768,7 +768,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "fsevents": {
@@ -778,8 +778,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.6.2",
-        "node-pre-gyp": "0.6.36"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.36"
       },
       "dependencies": {
         "abbrev": {
@@ -880,6 +880,7 @@
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
+          "optional": true,
           "requires": {
             "inherits": "2.0.3"
           }
@@ -889,6 +890,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -907,7 +909,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
           "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -927,13 +930,15 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "1.0.0"
           }
@@ -948,13 +953,15 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
@@ -1006,7 +1013,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -1036,7 +1044,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
           "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -1227,6 +1236,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -1242,7 +1252,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -1325,13 +1336,15 @@
           "version": "1.27.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
           "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "1.27.0"
           }
@@ -1413,7 +1426,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -1480,7 +1494,8 @@
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -1523,6 +1538,7 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
           "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "1.0.0",
             "core-util-is": "1.0.2",
@@ -1577,7 +1593,8 @@
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
           "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -1642,6 +1659,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -1653,6 +1671,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "5.0.1"
           }
@@ -1685,6 +1704,7 @@
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
+          "optional": true,
           "requires": {
             "block-stream": "0.0.9",
             "fstream": "1.0.11",
@@ -1746,7 +1766,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -1789,8 +1810,8 @@
       "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimatch": "0.3.0"
+        "inherits": "2",
+        "minimatch": "0.3"
       }
     },
     "glob-base": {
@@ -1799,8 +1820,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -1809,7 +1830,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -1842,8 +1863,8 @@
       "integrity": "sha1-tWLDRHk0mmkNemWX30la76jGBPU=",
       "dev": true,
       "requires": {
-        "Base64": "0.2.1",
-        "inherits": "2.0.3"
+        "Base64": "~0.2.0",
+        "inherits": "~2.0.1"
       }
     },
     "http-proxy": {
@@ -1852,8 +1873,8 @@
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
       }
     },
     "http-server": {
@@ -1863,13 +1884,13 @@
       "dev": true,
       "requires": {
         "colors": "1.0.3",
-        "corser": "2.0.1",
-        "ecstatic": "0.7.6",
-        "http-proxy": "1.16.2",
-        "opener": "1.4.3",
-        "optimist": "0.6.1",
-        "portfinder": "0.4.0",
-        "union": "0.4.6"
+        "corser": "~2.0.0",
+        "ecstatic": "~0.7.0",
+        "http-proxy": "^1.8.1",
+        "opener": "~1.4.0",
+        "optimist": "0.6.x",
+        "portfinder": "0.4.x",
+        "union": "~0.4.3"
       },
       "dependencies": {
         "optimist": {
@@ -1878,8 +1899,8 @@
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.10",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           }
         }
       }
@@ -1914,7 +1935,7 @@
       "integrity": "sha1-pSi1FOaJ/OkNswiehw2S9Sestes=",
       "dev": true,
       "requires": {
-        "source-map": "0.3.0"
+        "source-map": "~0.3.0"
       },
       "dependencies": {
         "source-map": {
@@ -1923,7 +1944,7 @@
           "integrity": "sha1-hYb7mloAXltQHiHNGLbyG0V60fk=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -1934,11 +1955,11 @@
       "integrity": "sha1-7snA360wOA6O2jE6CUFl3C8jUNI=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.7.4",
-        "concat-stream": "1.4.10",
-        "lexical-scope": "1.1.1",
-        "process": "0.6.0",
-        "through": "2.3.8"
+        "JSONStream": "~0.7.1",
+        "concat-stream": "~1.4.1",
+        "lexical-scope": "~1.1.0",
+        "process": "~0.6.0",
+        "through": "~2.3.4"
       }
     },
     "interpret": {
@@ -1953,7 +1974,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.10.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -1974,7 +1995,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -1995,7 +2016,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-number": {
@@ -2004,7 +2025,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-posix-bracket": {
@@ -2084,7 +2105,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -2099,7 +2120,7 @@
       "integrity": "sha1-3rrBBnQ18TWdkPz9npS8su5Hsr8=",
       "dev": true,
       "requires": {
-        "astw": "2.2.0"
+        "astw": "^2.0.0"
       }
     },
     "loader-utils": {
@@ -2108,10 +2129,10 @@
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "dev": true,
       "requires": {
-        "big.js": "3.1.3",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1",
-        "object-assign": "4.1.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
       }
     },
     "longest": {
@@ -2132,8 +2153,8 @@
       "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
       "dev": true,
       "requires": {
-        "errno": "0.1.4",
-        "readable-stream": "2.3.3"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -2148,13 +2169,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -2163,7 +2184,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -2174,19 +2195,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "mime": {
@@ -2201,8 +2222,8 @@
       "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.7.3",
-        "sigmund": "1.0.1"
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
       }
     },
     "minimist": {
@@ -2224,10 +2245,10 @@
       "dev": true,
       "requires": {
         "commander": "2.0.0",
-        "debug": "3.0.0",
+        "debug": "*",
         "diff": "1.0.7",
         "glob": "3.2.3",
-        "growl": "1.7.0",
+        "growl": "1.7.x",
         "jade": "0.26.3",
         "mkdirp": "0.3.5"
       },
@@ -2238,9 +2259,9 @@
           "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
           "dev": true,
           "requires": {
-            "graceful-fs": "2.0.3",
-            "inherits": "2.0.3",
-            "minimatch": "0.2.14"
+            "graceful-fs": "~2.0.0",
+            "inherits": "2",
+            "minimatch": "~0.2.11"
           }
         },
         "minimatch": {
@@ -2249,8 +2270,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -2261,14 +2282,14 @@
       "integrity": "sha1-V6nKydvQkkKOxSSfbPN/sknXfbY=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.7.4",
-        "browser-resolve": "1.2.4",
-        "concat-stream": "1.4.10",
-        "detective": "3.1.0",
-        "minimist": "0.0.10",
+        "JSONStream": "~0.7.1",
+        "browser-resolve": "~1.2.2",
+        "concat-stream": "~1.4.1",
+        "detective": "~3.1.0",
+        "minimist": "~0.0.5",
         "parents": "0.0.2",
-        "resolve": "0.6.3",
-        "through": "2.3.8"
+        "resolve": "~0.6.0",
+        "through": "~2.3.4"
       },
       "dependencies": {
         "parents": {
@@ -2298,28 +2319,28 @@
       "integrity": "sha1-PicsCBnjCJNeJmdECNevDhSRuDs=",
       "dev": true,
       "requires": {
-        "assert": "1.1.2",
-        "browserify-zlib": "0.1.4",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.9.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
         "crypto-browserify": "3.3.0",
-        "domain-browser": "1.1.7",
-        "events": "1.0.2",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
         "https-browserify": "0.0.1",
-        "os-browserify": "0.2.1",
+        "os-browserify": "^0.2.0",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.2.4",
-        "querystring-es3": "0.2.0",
-        "readable-stream": "2.3.3",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.7.2",
-        "string_decoder": "0.10.31",
-        "timers-browserify": "2.0.4",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.3.1",
+        "string_decoder": "^0.10.25",
+        "timers-browserify": "^2.0.2",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -2335,9 +2356,9 @@
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "dev": true,
           "requires": {
-            "base64-js": "1.2.1",
-            "ieee754": "1.1.8",
-            "isarray": "1.0.0"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
           }
         },
         "console-browserify": {
@@ -2346,7 +2367,7 @@
           "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
           "dev": true,
           "requires": {
-            "date-now": "0.1.4"
+            "date-now": "^0.1.4"
           }
         },
         "constants-browserify": {
@@ -2391,13 +2412,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           },
           "dependencies": {
             "string_decoder": {
@@ -2406,7 +2427,7 @@
               "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
               }
             }
           }
@@ -2417,8 +2438,8 @@
           "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3"
+            "inherits": "~2.0.1",
+            "readable-stream": "^2.0.2"
           }
         },
         "string_decoder": {
@@ -2433,7 +2454,7 @@
           "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
           "dev": true,
           "requires": {
-            "setimmediate": "1.0.5"
+            "setimmediate": "^1.0.4"
           }
         },
         "url": {
@@ -2462,7 +2483,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "object-assign": {
@@ -2483,8 +2504,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "opener": {
@@ -2499,7 +2520,7 @@
       "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
       "dev": true,
       "requires": {
-        "wordwrap": "0.0.3"
+        "wordwrap": "~0.0.2"
       }
     },
     "os-browserify": {
@@ -2520,7 +2541,7 @@
       "integrity": "sha1-+iEvAk2fpjGNu2tM5nbIvkk7nEM=",
       "dev": true,
       "requires": {
-        "path-platform": "0.0.1"
+        "path-platform": "^0.0.1"
       }
     },
     "parse-glob": {
@@ -2529,10 +2550,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "path-browserify": {
@@ -2566,7 +2587,7 @@
       "dev": true,
       "requires": {
         "async": "0.9.0",
-        "mkdirp": "0.5.1"
+        "mkdirp": "0.5.x"
       },
       "dependencies": {
         "async": {
@@ -2646,8 +2667,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -2656,7 +2677,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2665,7 +2686,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -2676,7 +2697,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -2687,10 +2708,10 @@
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
         "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "string_decoder": "~0.10.x"
       },
       "dependencies": {
         "string_decoder": {
@@ -2707,10 +2728,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       },
       "dependencies": {
         "graceful-fs": {
@@ -2731,7 +2752,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "readable-stream": {
@@ -2740,13 +2761,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -2755,7 +2776,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -2766,8 +2787,8 @@
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "^0.1.3",
+        "is-primitive": "^2.0.0"
       }
     },
     "remove-trailing-separator": {
@@ -2806,8 +2827,8 @@
       "integrity": "sha1-WXCM+Qyh50xUw8/Fw2/bmBBDUmE=",
       "dev": true,
       "requires": {
-        "callsite": "1.0.0",
-        "resolve": "0.3.1"
+        "callsite": "~1.0.0",
+        "resolve": "~0.3.0"
       },
       "dependencies": {
         "resolve": {
@@ -2824,7 +2845,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "ripemd160": {
@@ -2839,8 +2860,8 @@
       "integrity": "sha1-3Ikw4qlUSidDAcyZcldMDQmGtnU=",
       "dev": true,
       "requires": {
-        "rfile": "1.0.0",
-        "uglify-js": "2.2.5"
+        "rfile": "~1.0",
+        "uglify-js": "~2.2"
       },
       "dependencies": {
         "source-map": {
@@ -2849,7 +2870,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "uglify-js": {
@@ -2858,8 +2879,8 @@
           "integrity": "sha1-puAqcNg5eSuXgEiLe4sYTAlcmcc=",
           "dev": true,
           "requires": {
-            "optimist": "0.3.7",
-            "source-map": "0.1.43"
+            "optimist": "~0.3.5",
+            "source-map": "~0.1.7"
           }
         }
       }
@@ -2923,8 +2944,8 @@
       "integrity": "sha1-lc8bNpdy4nra9GNSJlFSaJxsS+k=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "process": "0.5.2"
+        "inherits": "~2.0.1",
+        "process": "~0.5.1"
       },
       "dependencies": {
         "process": {
@@ -2941,7 +2962,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "~0.1.1"
       }
     },
     "stream-http": {
@@ -2950,11 +2971,11 @@
       "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.2.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -2969,13 +2990,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -2984,7 +3005,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "xtend": {
@@ -3007,7 +3028,7 @@
       "integrity": "sha1-PVawfaz7xFu7Y/dnK0O2PkY2jjo=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10"
+        "minimist": "~0.0.7"
       }
     },
     "supports-color": {
@@ -3016,7 +3037,7 @@
       "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
       "dev": true,
       "requires": {
-        "has-flag": "1.0.0"
+        "has-flag": "^1.0.0"
       }
     },
     "syntax-error": {
@@ -3025,7 +3046,7 @@
       "integrity": "sha1-tFSXBtOGzBwdx8JCPxhXm2yt5xA=",
       "dev": true,
       "requires": {
-        "acorn": "2.7.0"
+        "acorn": "^2.7.0"
       },
       "dependencies": {
         "acorn": {
@@ -3054,8 +3075,8 @@
       "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34",
-        "xtend": "2.1.2"
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
       },
       "dependencies": {
         "readable-stream": {
@@ -3064,10 +3085,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3084,7 +3105,7 @@
       "integrity": "sha1-/7pwycEu7ZFv1nMY5imsbzIpVVE=",
       "dev": true,
       "requires": {
-        "process": "0.5.2"
+        "process": "~0.5.1"
       },
       "dependencies": {
         "process": {
@@ -3119,10 +3140,10 @@
       "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
+        "async": "~0.2.6",
         "source-map": "0.1.34",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.5.4"
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.5.4"
       },
       "dependencies": {
         "source-map": {
@@ -3131,7 +3152,7 @@
           "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -3148,10 +3169,10 @@
       "integrity": "sha1-dJaDsNUUcorg4bYZX1d0r8CtT48=",
       "dev": true,
       "requires": {
-        "rfile": "1.0.0",
-        "ruglify": "1.0.0",
-        "through": "2.3.8",
-        "uglify-js": "2.4.24"
+        "rfile": "~1.0.0",
+        "ruglify": "~1.0.0",
+        "through": "~2.3.4",
+        "uglify-js": "~2.4.0"
       }
     },
     "union": {
@@ -3160,7 +3181,7 @@
       "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
       "dev": true,
       "requires": {
-        "qs": "2.3.3"
+        "qs": "~2.3.3"
       }
     },
     "url": {
@@ -3225,9 +3246,9 @@
       "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
       "dev": true,
       "requires": {
-        "async": "0.9.2",
-        "chokidar": "1.7.0",
-        "graceful-fs": "4.1.11"
+        "async": "^0.9.0",
+        "chokidar": "^1.0.0",
+        "graceful-fs": "^4.1.2"
       },
       "dependencies": {
         "async": {
@@ -3250,21 +3271,21 @@
       "integrity": "sha1-T/MfU9sDM55VFkqdRo7gMklo/pg=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0",
-        "async": "1.5.2",
-        "clone": "1.0.2",
-        "enhanced-resolve": "0.9.1",
-        "interpret": "0.6.6",
-        "loader-utils": "0.2.17",
-        "memory-fs": "0.3.0",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "0.7.0",
-        "optimist": "0.6.1",
-        "supports-color": "3.2.3",
-        "tapable": "0.1.10",
-        "uglify-js": "2.7.5",
-        "watchpack": "0.2.9",
-        "webpack-core": "0.6.9"
+        "acorn": "^3.0.0",
+        "async": "^1.3.0",
+        "clone": "^1.0.2",
+        "enhanced-resolve": "~0.9.0",
+        "interpret": "^0.6.4",
+        "loader-utils": "^0.2.11",
+        "memory-fs": "~0.3.0",
+        "mkdirp": "~0.5.0",
+        "node-libs-browser": "^0.7.0",
+        "optimist": "~0.6.0",
+        "supports-color": "^3.1.0",
+        "tapable": "~0.1.8",
+        "uglify-js": "~2.7.3",
+        "watchpack": "^0.2.1",
+        "webpack-core": "~0.6.9"
       },
       "dependencies": {
         "acorn": {
@@ -3300,8 +3321,8 @@
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           }
         },
         "uglify-js": {
@@ -3310,10 +3331,10 @@
           "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
           "dev": true,
           "requires": {
-            "async": "0.2.10",
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "async": "~0.2.6",
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "async": {
@@ -3336,9 +3357,9 @@
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -3350,8 +3371,8 @@
       "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
       "dev": true,
       "requires": {
-        "source-list-map": "0.1.8",
-        "source-map": "0.4.4"
+        "source-list-map": "~0.1.7",
+        "source-map": "~0.4.1"
       },
       "dependencies": {
         "source-map": {
@@ -3360,7 +3381,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -3383,7 +3404,7 @@
       "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
       "dev": true,
       "requires": {
-        "object-keys": "0.4.0"
+        "object-keys": "~0.4.0"
       }
     },
     "yargs": {
@@ -3392,8 +3413,8 @@
       "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
       "dev": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0",
         "wordwrap": "0.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "buffer-from": "^1.0.0",
-    "source-map": "^0.6.0"
+    "source-map": "~0.6.0"
   },
   "devDependencies": {
     "browserify": "3.44.2",


### PR DESCRIPTION
According to breakable changes in [0.7.0](https://github.com/mozilla/source-map/blob/master/CHANGELOG.md#070) release:

**Breaking change:** `new SourceMapConsumer` now returns a `Promise` object that resolves to the newly constructed `SourceMapConsumer` instance, rather than returning the new instance immediately.