### PR TITLE
Fix `resetRetrieveHandlers` to reset `retrieveSourceMap` and `retrieveFile` functions

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -557,4 +557,7 @@ exports.resetRetrieveHandlers = function() {
 
   retrieveFileHandlers = originalRetrieveFileHandlers.slice(0);
   retrieveMapHandlers = originalRetrieveMapHandlers.slice(0);
+  
+  retrieveSourceMap = handlerExec(retrieveMapHandlers);
+  retrieveFile = handlerExec(retrieveFileHandlers);
 }


### PR DESCRIPTION
The `handlerExec` function produces functions that are using original `retrieveFileHandlers`/`retrieveMapHandlers` references, so because the array variables are  re-assigned in the `resetRetrieveHandlers` function, `retrieveSourceMap` and `retrieveFile` need to be re-created to point them to correct instances of `retrieveFileHandlers`/`retrieveMapHandlers`.

This fixes:
https://github.com/facebook/jest/issues/6424
https://github.com/facebook/jest/issues/7402