### PR TITLE
Fix: formatting in prepareStackTrace when error isn't of instance Error

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -384,14 +384,18 @@ function wrapCallSite(frame) {
 }
 
 // This function is part of the V8 stack trace API, for more info see:
-// http://code.google.com/p/v8/wiki/JavaScriptStackTraceApi
+// https://v8.dev/docs/stack-trace-api
 function prepareStackTrace(error, stack) {
   if (emptyCacheBetweenOperations) {
     fileContentsCache = {};
     sourceMapCache = {};
   }
 
-  return error + stack.map(function(frame) {
+  var name = error.name || 'Error';
+  var message = error.message || '';
+  var errorString = name + ": " + message;
+
+  return errorString + stack.map(function(frame) {
     return '\n    at ' + wrapCallSite(frame);
   }).join('');
 }

--- a/test.js
+++ b/test.js
@@ -622,3 +622,13 @@ it('handleUncaughtExceptions is true with existing listener', function(done) {
     done();
   });
 });
+
+it('normal console.trace', function(done) {
+  compareStdout(done, createMultiLineSourceMap(), [
+    'require("./source-map-support").install();',
+    'console.trace("test");'
+  ], [
+    'Trace: test',
+    /^    at Object\.<anonymous> \((?:.*[/\\])?line2\.js:1002:102\)$/
+  ]);
+});


### PR DESCRIPTION
`console.trace` sends an object with `name` and `message` instead of an `Error`,
thus rendering the function unusable due to erroneous message output of
`"[object Object]"`. This fixes #195