### PR TITLE
fix: function name should be obtained from next frame’s position

### DIFF
--- a/test.js
+++ b/test.js
@@ -331,7 +331,12 @@ it('maps original name from source', function() {
     generated: { line: 2, column: 8 },
     original: { line: 1000, column: 10 },
     source: '.original.js',
-    name: 'myOriginalName'
+  });
+  sourceMap.addMapping({
+    generated: { line: 4, column: 0 },
+    original: { line: 1002, column: 1 },
+    source: ".original.js",
+    name: "myOriginalName"
   });
   compareStackTrace(sourceMap, [
     'function foo() {',
@@ -341,7 +346,7 @@ it('maps original name from source', function() {
   ], [
     'Error: test',
     /^    at myOriginalName \((?:.*[/\\])?\.original.js:1000:11\)$/,
-    /^    at Object\.exports\.test \((?:.*[/\\])?\.generated.js:4:1\)$/
+    /^    at Object\.exports\.test \((?:.*[/\\])?\.original.js:1002:2\)$/
   ]);
 });
 


### PR DESCRIPTION
This is a follow-up to #220.

In #220 we provided `position.name` before `stack.getFunctionName` to support mangled function calls. However, `stack.getFunctionName` is supposed to return the name of the _current_ function, that is, which function does this frame live in. Regards to the source map, it is the `name` of the position in _next_ frame instead of in this frame.

To illustrate this issue, here is a reproducible [repository](https://github.com/JLHwung/source-map-support-bug) I revised from https://github.com/babel/babel/issues/9883:
```js
function foo() {
  console.log(new Error().stack);
}

function bar() {
  foo();    // <-- Here we are supposed to get `bar` as function name but instead get `foo`.
}

bar();
```

The expected output should be
```log
    at foo (/Users/jh/code/babel-sourcemap-bug/src/index.js:2:15)
    at bar (/Users/jh/code/babel-sourcemap-bug/src/index.js:6:3)
    at Object.<anonymous> (/Users/jh/code/babel-sourcemap-bug/src/index.js:9:1)
   // <--- frames below are omitted --->
```

The current output after requiring `source-map-support/register` is
```log
    at foo (/Users/jh/code/babel-sourcemap-bug/dist/src/index.js:2:15)
    at foo (/Users/jh/code/babel-sourcemap-bug/dist/src/index.js:6:3)
    at Object.<anonymous> (/Users/jh/code/babel-sourcemap-bug/dist/src/index.js:1:1)
    // <--- frames below are omitted --->
```
Apparently `foo` is incorrectly repeated.

To fix this issue, we reverse the stack processing order and introduce internal state to track next frame position. As `wrapCallSite` is exported as a public API, I would consider this change as a breaking change.