### PR TITLE
`register-hook-require` entry point

### DIFF
--- a/register-hook-require.js
+++ b/register-hook-require.js
@@ -1,0 +1,1 @@
+require('./').install({hookRequire: true});


### PR DESCRIPTION
Provide a `source-map-support/register-hook-require` entry-point (fixes #239)

