### PR TITLE
Expose emptyCache() function

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -398,12 +398,16 @@ function wrapCallSite(frame, state) {
   return frame;
 }
 
+function emptyCache() {
+  fileContentsCache = {};
+  sourceMapCache = {};
+}
+
 // This function is part of the V8 stack trace API, for more info see:
 // https://v8.dev/docs/stack-trace-api
 function prepareStackTrace(error, stack) {
   if (emptyCacheBetweenOperations) {
-    fileContentsCache = {};
-    sourceMapCache = {};
+    emptyCache();
   }
 
   var name = error.name || 'Error';
@@ -585,3 +589,5 @@ exports.resetRetrieveHandlers = function() {
   retrieveSourceMap = handlerExec(retrieveMapHandlers);
   retrieveFile = handlerExec(retrieveFileHandlers);
 }
+
+exports.emptyCache = emptyCache;


### PR DESCRIPTION
When using `cheap-module-eval-source-map` or equivalent in Webpack, the sourcemap is embbeded in the `eval()` statement generated by Webpack... thus, `source-map-support` cannot access the actual source and perform the mapping.

... and given that i'm using HMR on my nodejs server which is a huge codebase, using `source-map` is not an option if I dont want to wait forever on each file change.

Thus, I've developped for myself [a small webpack plugin](https://github.com/oguimbal/webpack-hmr-sourcemaps/tree/master) that mitigates this issue. But it requires `source-map-support` to expose an `emptyCache()` method.
