### PR TITLE
Fix Node.js Worker support by not shimming uncaughtException

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -568,8 +568,9 @@ exports.install = function(options) {
       // Don't let browserify try to resolve this require(), it's pointless
       // and breaks the build process.
       var worker_threads = require('worker_' + 'threads');
-      if (worker_threads.isMainThread === false)
+      if (worker_threads.isMainThread === false) {
         installHandler = false;
+      }
     } catch(e) {}
 
     // Provide the option to not install the uncaught exception handler. This is

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -561,6 +561,17 @@ exports.install = function(options) {
     var installHandler = 'handleUncaughtExceptions' in options ?
       options.handleUncaughtExceptions : true;
 
+    // Do not override 'uncaughtException' with our own handler in Node.js
+    // Worker threads. Workers pass the error to the main thread as an event,
+    // rather than printing something to stderr and exiting.
+    try {
+      // Don't let browserify try to resolve this require(), it's pointless
+      // and breaks the build process.
+      var worker_threads = require('worker_' + 'threads');
+      if (worker_threads.isMainThread === false)
+        installHandler = false;
+    } catch(e) {}
+
     // Provide the option to not install the uncaught exception handler. This is
     // to support other uncaught exception handlers (in test frameworks, for
     // example). If this handler is not installed and there are no other uncaught


### PR DESCRIPTION
Node.js Worker threads don’t handle `uncaughtException` the same way
that the main thread does. The shim does not apply/make sense here,
but breaks error handling support in unexpected ways instead.

Fixes: https://github.com/evanw/node-source-map-support/issues/268
Fixes: https://github.com/TypeStrong/ts-node/issues/945