### PR TITLE
Fix retrieveSourceMapURL to prevent false matches in CoffeeScript codebase

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -147,6 +147,8 @@ function retrieveSourceMapURL(source) {
 
   // Get the URL of the source map
   fileData = retrieveFile(source);
+  // Skip sourceMappingURL in coffeescript.js, meant for emitting source maps.
+  if (source.endsWith('node_modules/coffeescript/lib/coffeescript/coffeescript.js')) return null
   var re = /(?:\/\/[@#][\s]*sourceMappingURL=([^\s'"]+)[\s]*$)|(?:\/\*[@#][\s]*sourceMappingURL=([^\s*'"]+)[\s]*(?:\*\/)[\s]*$)/mg;
   // Keep executing the search to find the *last* sourceMappingURL to avoid
   // picking up sourceMappingURLs from comments, strings, etc.


### PR DESCRIPTION
This bug was hard to track down! It breaks all my tests, and has been a real hinderance to my _[jest-preset-coffeescript](https://github.com/danielbayley/jest-preset-coffeescript/runs/1254200867?check_suite_focus=true)_ package. Fixes #254.