### PR TITLE
Move from source-map to source-map-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3735,10 +3735,10 @@
       "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
       "dev": true
     },
-    "source-map": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.0.tgz",
-      "integrity": "sha512-mTozplhTX4tLKIHYji92OTZzVyZvi+Z1qRZDeBvQFI2XUB89wrRoj/xXad3c9NZ1GPJXXRvB+k41PQCPTMC+aA=="
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
     },
     "source-map-resolve": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "buffer-from": "^1.0.0",
-    "source-map": "^0.6.0"
+    "source-map-js": "^0.6.2"
   },
   "devDependencies": {
     "browserify": "^4.2.3",

--- a/source-map-support.js
+++ b/source-map-support.js
@@ -1,4 +1,4 @@
-var SourceMapConsumer = require('source-map').SourceMapConsumer;
+var SourceMapConsumer = require('source-map-js').SourceMapConsumer;
 var path = require('path');
 
 var fs;

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ require('./source-map-support').install({
   emptyCacheBetweenOperations: true // Needed to be able to test for failure
 });
 
-var SourceMapGenerator = require('source-map').SourceMapGenerator;
+var SourceMapGenerator = require('source-map-js').SourceMapGenerator;
 var child_process = require('child_process');
 var assert = require('assert');
 var fs = require('fs');


### PR DESCRIPTION
I made the fork of source-map@0.6 which is 4x times faster and still sync and written in JS only.

More info about fork here: https://github.com/7rulnik/source-map-js#difference-between-original-source-map

It partly solves https://github.com/evanw/node-source-map-support/issues/206

