### PR TITLE
fix: do not overwrite user-defined process's exit code to 1

### DIFF
--- a/source-map-support.js
+++ b/source-map-support.js
@@ -497,7 +497,7 @@ function printErrorAndExit (error) {
   }
 
   console.error(error.stack);
-  globalProcessExit(1);
+  globalProcessExit(process.exitCode || 1);
 }
 
 function shimEmitUncaughtException () {


### PR DESCRIPTION
Instead of exiting with 1 we must keep the user-land value defined for `process.exitCode` if it's non-zero otherwise we end up changing the error code defined by the consumer of this lib.

Code example:

```js
// app.js
require('source-map-support').install();
process.exitCode = 123
throw new Error('test 123')
```

after running `node app.js` I'm expecting to see `123` as the exit code but I'm getting `1`:

![image](https://github.com/evanw/node-source-map-support/assets/13461315/b7fd212b-8f82-47b9-a0b8-18b7a7eea83a)
